### PR TITLE
Another try with fresh base. Added notes to read.me template

### DIFF
--- a/_templates/BASE.md.erb
+++ b/_templates/BASE.md.erb
@@ -62,3 +62,24 @@ env:
 Every Snyk account has this token, and you can find it in one of two ways:	
 1. If you're using the [Snyk CLI](https://support.snyk.io/hc/en-us/articles/360003812458-Getting-started-with-the-CLI) you can retrieve it by running `snyk config get api`.	
 2. In the UI, go to your account's general settings page (https://app.snyk.io/account) and retrieve the API token, as shown in the following [Revoking and regenerating Snyk API tokens](https://support.snyk.io/hc/en-us/articles/360004008278-Revoking-and-regenerating-Snyk-API-tokens).
+
+
+Note: The above examples will halt the action when issues are found. If you want to ensure the action continues, even if Snyk finds issues, then [conmtinue-on-error]https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error will need to be set.
+
+```yaml
+name: Example workflow using Snyk with continue on error
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Run Snyk to check for vulnerabilities
+      uses: snyk/actions/node@master
+      continue-on-error: true
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        command: monitor
+```
+


### PR DESCRIPTION
Continue on error. Added a note for the ability to have someone understand how to "continue. on error" with a snyk scan. This will help usage since in some cases continue will be important vs error-ing out. 