### PR TITLE
Add python-3.8 variant

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -21,6 +21,7 @@ require 'fileutils'
   "Node",
   "PHP",
   "Python",
+  "Python-3.8",
   "Ruby",
   "Scala",
 ]

--- a/python-3.8/README.md
+++ b/python-3.8/README.md
@@ -1,0 +1,47 @@
+# Snyk Python 3.8 Action
+
+A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
+vulnerabilities in your Python projects.
+
+You can use the Action as follows:
+
+```yaml
+name: Example workflow for Python using Snyk 
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Run Snyk to check for vulnerabilities
+      uses: snyk/actions/python-3.8@master
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+```
+
+The Snyk Python Action has properties which are passed to the underlying image. These are
+passed to the action using `with`.
+
+| Property | Default | Description |
+| --- | --- | --- |
+| args |   | Override the default arguments to the Snyk image |
+| command | test | Specify which command to run, for instance test or monitor |
+| json | false | In addition to the stdout, save the results as snyk.json |
+
+For example, you can choose to only report on high severity vulnerabilities.
+
+```yaml
+name: Example workflow for Python using Snyk 
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Run Snyk to check for vulnerabilities
+      uses: snyk/actions/python-3.8@master
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        args: --severity-threshold=high
+```

--- a/python-3.8/action.yml
+++ b/python-3.8/action.yml
@@ -1,0 +1,25 @@
+name: 'Snyk Python'
+description: 'Check your Python application for vulnerabilties using Snyk'
+author: 'Gareth Rushgrove'
+branding:
+  icon: 'alert-triangle'
+  color: 'yellow'
+inputs:
+  command:
+    description: 'Which Snyk command to run, defaults to test'
+    default: test
+  args:
+    description: 'Additional arguments to pass to Snyk'
+  json:
+    description: 'Output a snyk.json file with results if running the test command'
+    default: false
+runs:
+  using: 'docker'
+  image: 'docker://snyk/snyk:python-3.8'
+  env:
+    SNYK_INTEGRATION_NAME: GITHUB_ACTIONS
+    SNYK_INTEGRATION_VERSION: python
+  args:
+    - snyk
+    - ${{ inputs.command }}
+    - ${{ inputs.args }}


### PR DESCRIPTION
Adding a Python 3.8 for an user.

Long-term, we should either extend templating for versions as well. Or even better sync this with tags on snyk/snyk images.

ZD 9266