### PR TITLE
docs: fix broken link for Snyk CLI reference

### DIFF
--- a/_templates/README.md.erb
+++ b/_templates/README.md.erb
@@ -1,7 +1,7 @@
 # Snyk <%= @name %><% if @ident %> (<%= @ident %>) <% end %> Action
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
-vulnerabilities in your <%= @variant %> projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
+vulnerabilities in your <%= @variant %> projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][https://docs.snyk.io/features/snyk-cli/cli-reference] with the `args`.
 
 You can use the Action as follows:
 
@@ -25,7 +25,7 @@ The Snyk <%= @name %> Action has properties which are passed to the underlying i
 
 | Property | Default | Description                                                                                         |
 | -------- | ------- | --------------------------------------------------------------------------------------------------- |
-| args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
+| args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][https://docs.snyk.io/features/snyk-cli/cli-reference] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
 


### PR DESCRIPTION
`_templates/README.md.erb` is referencing `[cli-ref]` in order to associate the Snyk CLI documentation. Unfortunately, the reference link leads to an HTTP 404.

Fixes: https://github.com/snyk/actions/issues/72