### PR TITLE
Add Gradle JDK 17 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ you are using. We currently support:
 - [Gradle-jdk12](gradle-jdk12)
 - [Gradle-jdk14](gradle-jdk14)
 - [Gradle-jdk16](gradle-jdk16)
+- [Gradle-jdk17](gradle-jdk17)
 - [Maven](maven)
 - [Maven-3-jdk-11](maven-3-jdk-11)
 - [Node](node)

--- a/build.rb
+++ b/build.rb
@@ -18,6 +18,7 @@ require 'fileutils'
   "Gradle-jdk12",
   "Gradle-jdk14",
   "Gradle-jdk16",
+  "Gradle-jdk17",
   "Maven",
   "Maven-3-jdk-11",
   "Node",

--- a/gradle-jdk17/README.md
+++ b/gradle-jdk17/README.md
@@ -1,0 +1,82 @@
+# Snyk Gradle (jdk17)  Action
+
+A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
+vulnerabilities in your Gradle-jdk17 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
+
+You can use the Action as follows:
+
+```yaml
+name: Example workflow for Gradle using Snyk
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/gradle-jdk17@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+```
+
+## Properties
+
+The Snyk Gradle Action has properties which are passed to the underlying image. These are passed to the action using `with`.
+
+| Property | Default | Description                                                                                         |
+| -------- | ------- | --------------------------------------------------------------------------------------------------- |
+| args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
+| command  | test    | Specify which command to run, for instance test or monitor                                          |
+| json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+
+For example, you can choose to only report on high severity vulnerabilities.
+
+```yaml
+name: Example workflow for Gradle using Snyk
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/gradle-jdk17@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high
+```
+
+## Uploading Snyk scan results to GitHub Code Scanning
+
+Using `--sarif-file-output` [Snyk CLI flag][cli-ref] and the [official GitHub SARIF upload action](https://docs.github.com/en/code-security/secure-coding/uploading-a-sarif-file-to-github), you can upload Snyk scan results to the GitHub Code Scanning.
+
+![Snyk results as a SARIF output uploaded to GitHub Code Scanning](../_templates/sarif-example.png)
+
+The Snyk Action will fail when vulnerabilities are found. This would prevent the SARIF upload action from running, so we need to introduce a [continue-on-error](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) option like this:
+
+```yaml
+name: Example workflow for Gradle using Snyk
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/gradle-jdk17@master
+        continue-on-error: true # To make sure that SARIF upload gets called
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --sarif-file-output=snyk.sarif
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif
+```
+
+Made with 💜 by Snyk
+
+[cli-gh]: https://github.com/snyk/snyk 'Snyk CLI'
+[cli-ref]: https://snyk.io/docs/using-snyk?utm_campaign=docs&utm_medium=github&utm_source=cli 'Snyk CLI Reference documentation'

--- a/gradle-jdk17/action.yml
+++ b/gradle-jdk17/action.yml
@@ -1,0 +1,26 @@
+name: "Snyk Gradle (jdk17)"
+description: "Check your Gradle application for vulnerabilties using Snyk"
+author: "Gareth Rushgrove"
+branding:
+  icon: "alert-triangle"
+  color: "yellow"
+inputs:
+  command:
+    description: "Which Snyk command to run, defaults to test"
+    default: test
+  args:
+    description: "Additional arguments to pass to Snyk"
+  json:
+    description: "Output a snyk.json file with results if running the test command"
+    default: false
+runs:
+  using: "docker"
+  image: "docker://snyk/snyk:gradle-jdk17"
+  env:
+    FORCE_COLOR: 2
+    SNYK_INTEGRATION_NAME: GITHUB_ACTIONS
+    SNYK_INTEGRATION_VERSION: gradle-jdk17
+  args:
+  - snyk
+  - ${{ inputs.command }}
+  - ${{ inputs.args }} 


### PR DESCRIPTION
As the docker image for Gradle JDK 17 is now available (see https://github.com/snyk/snyk-images/pull/33), this PR adds the integration for GitHub actions.