### PR TITLE
chore: have CI badge link to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Snyk GitHub Actions
 
-![](https://github.com/snyk/actions/workflows/Generate%20Snyk%20GitHub%20Actions/badge.svg)
+[![](https://github.com/snyk/actions/workflows/Generate%20Snyk%20GitHub%20Actions/badge.svg)](https://github.com/snyk/actions/actions/workflows/schedule.yml)
 
 A set of [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your GitHub projects. A different action is required depending on which language or build tool


### PR DESCRIPTION
Updating README badge to link to corresponding `Actions` build page and not just the `.svg` image.

Example: test out clicking badge [here](https://github.com/jackwotherspoon/actions/blob/master/README.md)