### PR TITLE
Replace deprecated set-output with GITHUB_OUTPUT

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -19,4 +19,4 @@ runs:
       shell: bash
     - id: version
       shell: bash
-      run: echo ::set-output name=version::"$(snyk version)"
+      run: echo "version=$(snyk version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
When running the GitHub Action for snyk-setup-action: https://github.com/snyk/actions/tree/master/setup#snyk-setup-action, I get an error that the set-output is deprecated in GitHub Actions:
![image](https://user-images.githubusercontent.com/8502070/198991709-e9501394-8016-4e68-ba35-483fe2106ffc.png)


This PR changes set-output to use the GITHUB_OUTPUT instead as recommended by GitHub: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/