### PR TITLE
fix: refined iac test action readme [CFG-1631]

### DIFF
--- a/iac/README.md
+++ b/iac/README.md
@@ -12,26 +12,32 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Run Snyk to check Kubernetes manifest file for issues
         uses: snyk/actions/iac@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          file: your/kubernetes-manifest.yaml
 ```
 
+In order to use the Snyk Infrastructure as Code Test Action, you will need to have a Snyk API token. 
+More details in [Getting Your Snyk Token](https://github.com/snyk/actions#getting-your-snyk-token), or you can [sign up for free](https://snyk.io/login).  
+
+
 The Snyk Infrastructure as Code Action has properties which are passed to the underlying image. These are
-passed to the action using `with`.
+passed to the action using `with`:
 
-| Property | Default | Description                                                      |
-|----------|---------|------------------------------------------------------------------|
-| args     |         | Override the default arguments to the Snyk image                 |
-| command  | test    | Specify which command to run, currently only `test` is supported |
-| file     |         | The file to check for issues.                                    |
-| json     | false   | In addition to the stdout, save the results as snyk.json         |
-| sarif    | true    | In addition to the stdout, save the results as snyk.sarif        |
+| Property  | Default | Description                                                        |
+|-----------|----------|-------------------------------------------------------------------|
+| `args`    |          | Override the default arguments to the Snyk image.                 |
+| `command` | `"test"` | Specify which command to run, currently only `test` is supported. |
+| `file`    |          | The paths in which to scan files with issues.                     |
+| `json`    | `false`  | In addition to the stdout, save the results as snyk.json          |
+| `sarif`   | `true`   | In addition to the stdout, save the results as snyk.sarif         |
 
-For example, you can choose to only report on high severity vulnerabilities.
+## Examples
+### Specifying paths
+You can specify the paths to the configuration files and directories to target during the test.  
+When no path is specified, the whole repository is scanned by default:
 
 ```yaml
 name: Example workflow for Snyk Infrastructure as Code
@@ -40,6 +46,26 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+      - name: Run Snyk to check Kubernetes manifest file for issues
+        uses: snyk/actions/iac@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          file: your/kubernetes-manifest.yaml your/terraform/directory
+```
+
+### Specifying severity threshold
+You can also choose to only report on high severity vulnerabilities:
+
+```yaml
+name: Example workflow for Snyk Infrastructure as Code
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
       - name: Run Snyk to check Kubernetes manifest file for issues
         uses: snyk/actions/iac@master
         env:
@@ -48,8 +74,46 @@ jobs:
           file: your/kubernetes-manifest.yaml
           args: --severity-threshold=high
 ```
+### Sharing test results
+You can [share your test results](https://docs.snyk.io/products/snyk-infrastructure-as-code/share-cli-results-with-the-snyk-web-ui) to the Snyk platform:
 
-The Infrastructure as Code Action also supports integrating with GitHub Code Scanning and can show issues in the GitHub Security tab. When run, a `snyk.sarif` file will be generated which can be uploaded to GitHub Code Scanning.
+```yaml
+name: Example workflow for Snyk Infrastructure as Code
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Snyk to check Kubernetes manifest file for issues
+        uses: snyk/actions/iac@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --report
+```
+### Specifying scan mode for Terraform Plan
+You can also choose the [scan mode](https://docs.snyk.io/products/snyk-infrastructure-as-code/snyk-cli-for-infrastructure-as-code/test-your-terraform-files-with-the-cli-tool#terraform-plan), when scanning Terraform Plan files:
+
+```yaml
+name: Example workflow for Snyk Infrastructure as Code
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Snyk to check Kubernetes manifest file for issues
+        uses: snyk/actions/iac@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --scan=resource-changes
+```
+
+### Integrating with GitHub Code Scanning
+
+The Infrastructure as Code Action also supports integrating with GitHub Code Scanning and can show issues in the GitHub Security tab. When run, a `snyk.sarif` file will be generated which can be uploaded to GitHub Code Scanning:
 
 ```yaml
 name: Snyk Infrastructure as Code
@@ -65,44 +129,14 @@ jobs:
         continue-on-error: true
         uses: snyk/actions/iac@master
         env:
-          # In order to use the Snyk Action you will need to have a Snyk API token.
-          # More details in https://github.com/snyk/actions#getting-your-snyk-token
-          # or you can signup for free at https://snyk.io/login
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          # Add the path to the configuration file that you would like to test.
-          # For example `deployment.yaml` for a Kubernetes deployment manifest
-          # or `main.tf` for a Terraform configuration file
-          file: your-file-to-test.yaml
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: snyk.sarif
 ```
 
-### Specifying Multiple Files
-
-If you want to run IaC tests against multiple files, the [Build Matrix](https://docs.github.com/en/actions/using-jobs/using-a-build-matrix-for-your-jobs) feature can be used.
-
-```yaml
-name: Example workflow for Snyk Infrastructure as Code with multiple files
-on: push
-jobs:
-  security:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        files:
-          - main.tf
-          - outputs.tf
-          - variables.tf
-    steps:
-      - name: Run Snyk to check Kubernetes manifest file for issues
-        uses: snyk/actions/iac@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          file: ${{ matrix.files }}
-```
-
-The Actions example above refers to a `files` list that must contain at least _one_ supported file.
+## Related Documentation
+For more information on how to use the `snyk iac test` command, see the following: 
+- [Snyk CLI for Infastructure as Code](https://docs.snyk.io/products/snyk-infrastructure-as-code/snyk-cli-for-infrastructure-as-code)
+- [Snyk Infrastructure as Code Test Command](https://docs.snyk.io/snyk-cli/commands/iac-test)

--- a/iac/example.yml
+++ b/iac/example.yml
@@ -22,12 +22,11 @@ jobs:
           # More details in https://github.com/snyk/actions#getting-your-snyk-token
           # or you can signup for free at https://snyk.io/login
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          # Scan the whole repository
-          file: . 
-          # Alternatively, add the path to the configuration file that you would like to test.
-          # For example `deployment.yaml` for a Kubernetes deployment manifest
-          # or `main.tf` for a Terraform configuration file
+        # Scans the whole repository by default.
+        # Alternatively, add the path to the configuration file that you would like to test.
+        # For example `deployment.yaml` for a Kubernetes deployment manifest
+        # or `main.tf` for a Terraform configuration file
+        # with:
           # file: your-file-to-test.yaml
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
### What this does

- Updates the example to not specify a path, scanning the whole repo by default.
- Clarifies the `file` input arg supports multiple paths for both directories and files.
- Adds more examples of the action with key features: Sharing CLI test results to the platform, and adding a scan mode for Terraform Plan.
- Adds references to the docs for more information.

### Background context

- The current examples show:
    - Scanning a specific file.
    - Using `--severity-threshold`.
    - Multiple files - one by one, when we actually support multiple paths with a single execution.
    - Integrating GitHub Code Scanning.
- The default experience for this GitHub action should be to scan directories by default.
- Additionally, we do not show how to use the other flags that we support such as `--scan` and `--report`

### Additional Information

- [Slack thread](https://snyk.slack.com/archives/CMM9V3XPY/p1669639975203079)
- [CFG-1631](https://snyksec.atlassian.net/browse/CFG-1631)