### PR TITLE
Fix README.md in templates

### DIFF
--- a/_templates/README.md.erb
+++ b/_templates/README.md.erb
@@ -3,7 +3,7 @@
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your <%= @variant %> projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-<% if @name = "Python" %> > Note: The examples shared below reflect how Snyk github actions can be used. Snyk requires Python to have downloaded the dependencies before running or triggering the Snyk checks.
+<% if @name == "Python" %> > Note: The examples shared below reflect how Snyk github actions can be used. Snyk requires Python to have downloaded the dependencies before running or triggering the Snyk checks.
                           > The Python image checks and installs deps only if the manifest files are present in the current path (from where action is being triggered)
                           > 1. If pip is present on the current path , and Snyk finds a requirements.txt file, then Snyk runs pip install -r requirements.txt.
                           > 2. If pipenv is present on the current path, and Snyk finds a Pipfile without a Pipfile.lock, then Snyk runs pipenv update


### PR DESCRIPTION
In the README of each language, the workflows and explanations were written for Python.
After investigating the cause, we found that in README.md.erb, a judgment expression for the if the condition was incorrectly set to the value of "Python" in @name.
Therefore we fixed this.
refs: https://github.com/snyk/actions/commit/0e928f3e9ae859e2b95ac2b89af55d7b6434244d
