### PR TITLE
Updates set-output command

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -19,4 +19,4 @@ runs:
       shell: bash
     - id: version
       shell: bash
-      run: echo ::set-output name=version::"$(snyk version)"
+      run: echo name=version::"$(snyk version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
GitHub is reporting warnings that `set-output` command is deprecated and suggest usage of `$GITHUB_OUTPUT`.

Full warning message:
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```