### PR TITLE
feat: add ability for customer to specify custom docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,25 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
 
+### Using a custom container image for actions
+
+This example is useful if you wish to pull the images used by the actions from an on-premise container registry. You must ensure that you copy the upstream images to your local container registry, and then in your actions you can specify your custom image. If no image is specified, the default (hosted in DockerHub) will be used.
+```yaml
+name: Example workflow using Snyk
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          docker_image: my-onprem-image:golang
+```
+
 Made with 💜 by Snyk
 
 [cli-gh]: https://github.com/snyk/snyk 'Snyk CLI'

--- a/_templates/BASE.md.erb
+++ b/_templates/BASE.md.erb
@@ -113,6 +113,25 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
 
+### Using a custom container image for actions
+
+This example is useful if you wish to pull the images used by the actions from an on-premise container registry. You must ensure that you copy the upstream images to your local container registry, and then in your actions you can specify your custom image. If no image is specified, the default (hosted in DockerHub) will be used.
+```yaml
+name: Example workflow using Snyk
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          docker_image: my-onprem-image:golang
+```
+
 Made with 💜 by Snyk
 
 [cli-gh]: https://github.com/snyk/snyk 'Snyk CLI'

--- a/_templates/README.md.erb
+++ b/_templates/README.md.erb
@@ -36,6 +36,7 @@ The Snyk <%= @name %> Action has properties which are passed to the underlying i
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/_templates/action.yml.erb
+++ b/_templates/action.yml.erb
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:<%= @variant.downcase %>"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:<%= @variant.downcase %>"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/cocoapods/README.md
+++ b/cocoapods/README.md
@@ -29,6 +29,7 @@ The Snyk CocoaPods Action has properties which are passed to the underlying imag
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/cocoapods/action.yml
+++ b/cocoapods/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:cocoapods"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:cocoapods"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -29,6 +29,7 @@ The Snyk dotNET Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/dotnet/action.yml
+++ b/dotnet/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:dotnet"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:dotnet"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/golang/README.md
+++ b/golang/README.md
@@ -29,6 +29,7 @@ The Snyk Golang Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/golang/action.yml
+++ b/golang/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:golang"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:golang"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/gradle-jdk11/README.md
+++ b/gradle-jdk11/README.md
@@ -29,6 +29,7 @@ The Snyk Gradle Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/gradle-jdk11/action.yml
+++ b/gradle-jdk11/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:gradle-jdk11"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:gradle-jdk11"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/gradle-jdk12/README.md
+++ b/gradle-jdk12/README.md
@@ -29,6 +29,7 @@ The Snyk Gradle Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/gradle-jdk12/action.yml
+++ b/gradle-jdk12/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:gradle-jdk12"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:gradle-jdk12"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/gradle-jdk14/README.md
+++ b/gradle-jdk14/README.md
@@ -29,6 +29,7 @@ The Snyk Gradle Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/gradle-jdk14/action.yml
+++ b/gradle-jdk14/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:gradle-jdk14"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:gradle-jdk14"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/gradle-jdk16/README.md
+++ b/gradle-jdk16/README.md
@@ -29,6 +29,7 @@ The Snyk Gradle Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/gradle-jdk16/action.yml
+++ b/gradle-jdk16/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:gradle-jdk16"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:gradle-jdk16"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/gradle-jdk17/README.md
+++ b/gradle-jdk17/README.md
@@ -29,6 +29,7 @@ The Snyk Gradle Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/gradle-jdk17/action.yml
+++ b/gradle-jdk17/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:gradle-jdk17"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:gradle-jdk17"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -29,6 +29,7 @@ The Snyk Gradle Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/gradle/action.yml
+++ b/gradle/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:gradle"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:gradle"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/maven-3-jdk-11/README.md
+++ b/maven-3-jdk-11/README.md
@@ -29,6 +29,7 @@ The Snyk Maven Action has properties which are passed to the underlying image. T
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/maven-3-jdk-11/action.yml
+++ b/maven-3-jdk-11/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:maven-3-jdk-11"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:maven-3-jdk-11"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/maven/README.md
+++ b/maven/README.md
@@ -29,6 +29,7 @@ The Snyk Maven Action has properties which are passed to the underlying image. T
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/maven/action.yml
+++ b/maven/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:maven"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:maven"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/node/README.md
+++ b/node/README.md
@@ -29,6 +29,7 @@ The Snyk Node Action has properties which are passed to the underlying image. Th
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/node/action.yml
+++ b/node/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:node"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:node"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/php/README.md
+++ b/php/README.md
@@ -29,6 +29,7 @@ The Snyk PHP Action has properties which are passed to the underlying image. The
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/php/action.yml
+++ b/php/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:php"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:php"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/python-3.10/README.md
+++ b/python-3.10/README.md
@@ -36,6 +36,7 @@ The Snyk Python Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/python-3.10/action.yml
+++ b/python-3.10/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:python-3.10"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:python-3.10"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/python-3.6/README.md
+++ b/python-3.6/README.md
@@ -36,6 +36,7 @@ The Snyk Python Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/python-3.6/action.yml
+++ b/python-3.6/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:python-3.6"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:python-3.6"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/python-3.7/README.md
+++ b/python-3.7/README.md
@@ -36,6 +36,7 @@ The Snyk Python Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/python-3.7/action.yml
+++ b/python-3.7/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:python-3.7"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:python-3.7"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/python-3.8/README.md
+++ b/python-3.8/README.md
@@ -36,6 +36,7 @@ The Snyk Python Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/python-3.8/action.yml
+++ b/python-3.8/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:python-3.8"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:python-3.8"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/python-3.9/README.md
+++ b/python-3.9/README.md
@@ -36,6 +36,7 @@ The Snyk Python Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/python-3.9/action.yml
+++ b/python-3.9/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:python-3.9"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:python-3.9"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/python/README.md
+++ b/python/README.md
@@ -36,6 +36,7 @@ The Snyk Python Action has properties which are passed to the underlying image. 
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/python/action.yml
+++ b/python/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:python"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:python"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -29,6 +29,7 @@ The Snyk Ruby Action has properties which are passed to the underlying image. Th
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/ruby/action.yml
+++ b/ruby/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:ruby"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:ruby"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS

--- a/scala/README.md
+++ b/scala/README.md
@@ -29,6 +29,7 @@ The Snyk Scala Action has properties which are passed to the underlying image. T
 | args     |         | Override the default arguments to the Snyk image. See [Snyk CLI reference for all options][cli-ref] |
 | command  | test    | Specify which command to run, for instance test or monitor                                          |
 | json     | false   | In addition to the stdout, save the results as snyk.json                                            |
+| docker_image     | dockerhub-image   | Overridden docker image, allows using a custom image                                            |
 
 For example, you can choose to only report on high severity vulnerabilities.
 

--- a/scala/action.yml
+++ b/scala/action.yml
@@ -13,9 +13,12 @@ inputs:
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
+  docker_image:
+    description: "Specify a docker image to use for this action, useful if you want to override the default image"
+    default: "snyk/snyk:scala"
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:scala"
+  image: "docker://${{ inputs.docker_image }}"
   env:
     FORCE_COLOR: 2
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS


### PR DESCRIPTION
**What this does:**
Adds a `docker_image` parameter to applicable actions which will allow customers to use their own custom images if required. 

To use your own docker image you'd have to run the login flow to your image registry and then specify the full url of the docker image in the `docker_image` variable:

`my-artifactory-instance.jfrog.io/my-docker-repo/my-image:tag`