### PR TITLE
Replace github.action_path to GITHUB_ACTION_PATH in setup

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -15,7 +15,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/setup_snyk.sh ${{ inputs.snyk-version }} ${{ runner.os }}
+    - run: ${GITHUB_ACTION_PATH}/setup_snyk.sh ${{ inputs.snyk-version }} ${{ runner.os }}
       shell: bash
     - id: version
       shell: bash


### PR DESCRIPTION
Due to the bug of GitHub Action Runner (https://github.com/actions/runner/issues/716), github.action_path context value is not evaluated into valid path in containers on self-hosted runners. The corresponding environment variable GITHUB_ACTION_PATH always contains valid path even actions running on self-hosted runners, so this PR replaces github.action_path context into GITHUB_ACTION_PATH environment variable.