### PR TITLE
fix: In setup action check if sudo is available

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,3 +25,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Snyk CLI
         uses: ./setup/
+  test-setup-action-no-sudo:
+    name: test-setup-action-no-sudo
+    runs-on: ubuntu-latest
+    container:
+      image: debian:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install curl
+        run: apt-get update && apt-get install curl --yes
+      - name: Set up Snyk CLI
+        uses: ./setup/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.dccache

--- a/setup/README.md
+++ b/setup/README.md
@@ -26,6 +26,8 @@ jobs:
 When using the Setup Action you are responsible for setting up the development environment required to run Snyk.
 In this case this is a Go project so `actions/setup-go` was used, but this would be specific to your project. The [language and frameworks guides](https://docs.github.com/en/actions/language-and-framework-guides) are a good starting point.
 
+The Setup Action requires `bash` and `curl` to be available and requires privileges to write to `/usr/local/bin`, it'll try to use `sudo` to gain these privileges. 
+
 The Snyk Setup Action has properties which are passed to the underlying image. These are
 passed to the action using `with`.
 

--- a/setup/setup_snyk.sh
+++ b/setup/setup_snyk.sh
@@ -27,6 +27,7 @@ echo "Installing the $1 version of Snyk on $2"
 
 VERSION=$1
 BASE_URL="https://static.snyk.io/cli"
+SUDO_CMD="sudo"
 
 case "$2" in
     Linux)
@@ -50,13 +51,20 @@ esac
     echo eval snyk-${PREFIX} \$@
 } > snyk
 
+if ! command -v "$SUDO_CMD" &> /dev/null; then
+  echo "$SUDO_CMD is NOT installed. Trying without sudo, expecting privileges to write to '/usr/local/bin'."
+  SUDO_CMD=""
+else
+    echo "$SUDO_CMD is installed."
+fi
+
 chmod +x snyk
-sudo mv snyk /usr/local/bin
+${SUDO_CMD} mv snyk /usr/local/bin
 
 curl --compressed --retry 2 --output snyk-${PREFIX} "$BASE_URL/$VERSION/snyk-${PREFIX}" 
 curl --compressed --retry 2 --output snyk-${PREFIX}.sha256 "$BASE_URL/$VERSION/snyk-${PREFIX}.sha256"
 
 sha256sum -c snyk-${PREFIX}.sha256
 chmod +x snyk-${PREFIX}
-sudo mv snyk-${PREFIX} /usr/local/bin
+${SUDO_CMD} mv snyk-${PREFIX} /usr/local/bin
 rm -rf snyk*


### PR DESCRIPTION
* Not all environments might have `sudo` installed, this PR makes sudo usage optional but it requires the executing user to have the privileges to write to `/usr/local/bin`.
* Added a test for such an environment based on debian.