### PR TITLE
feat: change downloadurl and add fallback on setup action

### DIFF
--- a/setup/setup_snyk.sh
+++ b/setup/setup_snyk.sh
@@ -29,6 +29,7 @@ VERSION=$1
 MAIN_URL="https://downloads.snyk.io/cli"
 BACKUP_URL="https://static.snyk.io/cli"
 SUDO_CMD="sudo"
+GH_ACTIONS="GITHUB_ACTIONS"
 
 # Determine the prefix based on the platform
 case "$2" in
@@ -41,7 +42,7 @@ esac
 
 {
     echo "#!/bin/bash"
-    echo export SNYK_INTEGRATION_NAME="GITHUB_ACTIONS"
+    echo export SNYK_INTEGRATION_NAME=\"$GH_ACTIONS\"
     echo export SNYK_INTEGRATION_VERSION=\"setup \(${2}\)\"
     echo export FORCE_COLOR=2
     echo eval snyk-${PREFIX} \$@
@@ -62,10 +63,10 @@ ${SUDO_CMD} mv snyk /usr/local/bin
 #   $2: Output file name
 download_file() {
     # Try to download from the main URL
-    if curl --compressed --retry 2 --output "$2" "$MAIN_URL/$1?utm_source=GITHUB_ACTIONS"; then
+    if curl --compressed --retry 2 --output "$2" "$MAIN_URL/$1?utm_source="$GH_ACTIONS; then
         echo "Downloaded $1 from main URL"
     # If main URL fails, try the backup URL
-    elif curl --compressed --retry 2 --output "$2" "$BACKUP_URL/$1?utm_source=GITHUB_ACTIONS"; then
+    elif curl --compressed --retry 2 --output "$2" "$BACKUP_URL/$1?utm_source="$GH_ACTIONS; then
         echo "Downloaded $1 from backup URL"
     # If both URLs fail, return an error
     else

--- a/setup/setup_snyk.sh
+++ b/setup/setup_snyk.sh
@@ -62,10 +62,10 @@ ${SUDO_CMD} mv snyk /usr/local/bin
 #   $2: Output file name
 download_file() {
     # Try to download from the main URL
-    if curl --compressed --retry 2 --output "$2" "$MAIN_URL/$1"; then
+    if curl --compressed --retry 2 --output "$2" "$MAIN_URL/$1?utm_source=GITHUB_ACTIONS"; then
         echo "Downloaded $1 from main URL"
     # If main URL fails, try the backup URL
-    elif curl --compressed --retry 2 --output "$2" "$BACKUP_URL/$1"; then
+    elif curl --compressed --retry 2 --output "$2" "$BACKUP_URL/$1?utm_source=GITHUB_ACTIONS"; then
         echo "Downloaded $1 from backup URL"
     # If both URLs fail, return an error
     else

--- a/setup/setup_snyk.sh
+++ b/setup/setup_snyk.sh
@@ -62,10 +62,10 @@ ${SUDO_CMD} mv snyk /usr/local/bin
 #   $2: Output file name
 download_file() {
     # Try to download from the main URL
-    if curl -Ls --fail "$MAIN_URL/$1" -o "$2"; then
+    if curl --compressed --retry 2 --output "$2" "$MAIN_URL/$1"; then
         echo "Downloaded $1 from main URL"
     # If main URL fails, try the backup URL
-    elif curl -Ls --fail "$BACKUP_URL/$1" -o "$2"; then
+    elif curl --compressed --retry 2 --output "$2" "$BACKUP_URL/$1"; then
         echo "Downloaded $1 from backup URL"
     # If both URLs fail, return an error
     else


### PR DESCRIPTION
## Summary
This PR changes the default download url to https://downloads.snyk.io, adds a backup URL that uses https://static.sn yk.io, for downloading the Snyk CLI

## Changes
- Changed base URL (https://downloads.snyk.io/cli)
- Added a backup URL (https://static.snyk.io/cli) to fall back on if the main URL fails
- Implemented a `download_file` function that attempts to download from the main URL first, then the backup URL if needed
- Updated the download process for both the Snyk binary and its SHA256 checksum file to use this new function

## Motivation
This is done as part of our AKAMAI Ion <> Download Delivery migration

## Testing
Tested the script to ensure:
- Successful downloads from the main URL
- Fallback to the backup URL when the main URL fails
- Proper error handling if both URLs fail

Please review and test in your environment to ensure it meets our reliability standards.