### PR TITLE
feat: change downloadurl and add fallback on setup action

### DIFF
--- a/setup/setup_snyk.sh
+++ b/setup/setup_snyk.sh
@@ -67,7 +67,7 @@ download_file() {
         echo "Downloaded from $MAIN_URL/$1"
     # If main URL fails, try the backup URL
     elif curl --compressed --retry 2 --output "$2" "$BACKUP_URL/$1?utm_source="$GH_ACTIONS; then
-        echo "Downloaded $1 from backup URL"
+        echo "Downloaded from $BACKUP_URL/$1"
     # If both URLs fail, return an error
     else
         echo "Failed to download $1 from both URLs"

--- a/setup/setup_snyk.sh
+++ b/setup/setup_snyk.sh
@@ -64,7 +64,7 @@ ${SUDO_CMD} mv snyk /usr/local/bin
 download_file() {
     # Try to download from the main URL
     if curl --compressed --retry 2 --output "$2" "$MAIN_URL/$1?utm_source="$GH_ACTIONS; then
-        echo "Downloaded $1 from main URL"
+        echo "Downloaded from $MAIN_URL/$1"
     # If main URL fails, try the backup URL
     elif curl --compressed --retry 2 --output "$2" "$BACKUP_URL/$1?utm_source="$GH_ACTIONS; then
         echo "Downloaded $1 from backup URL"

--- a/setup/setup_snyk.sh
+++ b/setup/setup_snyk.sh
@@ -19,36 +19,30 @@ die () {
     exit 1
 }
 
-[ "$#" -eq 2 ] || die "Setup Snyk requires two argument, $# provided"
+# Check if correct number of arguments is provided
+[ "$#" -eq 2 ] || die "Setup Snyk requires two arguments, $# provided"
 
 cd "$(mktemp -d)"
-
 echo "Installing the $1 version of Snyk on $2"
 
 VERSION=$1
-BASE_URL="https://static.snyk.io/cli"
+MAIN_URL="https://downloads.snyk.io/cli"
+BACKUP_URL="https://static.snyk.io/cli"
 SUDO_CMD="sudo"
+GH_ACTIONS="GITHUB_ACTIONS"
 
+# Determine the prefix based on the platform
 case "$2" in
-    Linux)
-        PREFIX=linux
-        ;;
-    Windows)
-        die "Windows runner not currently supported"
-        ;;
-    macOS)
-        PREFIX=macos
-        ;;
-    Alpine)
-        PREFIX=alpine
-        ;;
-    *)
-        die "Invalid runner specified: $2"
+    Linux)   PREFIX=linux ;;
+    macOS)   PREFIX=macos ;;
+    Alpine)  PREFIX=alpine ;;
+    Windows) die "Windows runner not currently supported" ;;
+    *)       die "Invalid runner specified: $2" ;;
 esac
 
 {
     echo "#!/bin/bash"
-    echo export SNYK_INTEGRATION_NAME="GITHUB_ACTIONS"
+    echo export SNYK_INTEGRATION_NAME=\"$GH_ACTIONS\"
     echo export SNYK_INTEGRATION_VERSION=\"setup \(${2}\)\"
     echo export FORCE_COLOR=2
     echo eval snyk-${PREFIX} \$@
@@ -63,11 +57,40 @@ fi
 
 chmod +x snyk
 ${SUDO_CMD} mv snyk /usr/local/bin
+# Function to download a file with fallback to backup URL
+# Parameters:
+#   $1: File name to download
+#   $2: Output file name
+download_file() {
+    # Try to download from the main URL
+    if curl --compressed --retry 2 --output "$2" "$MAIN_URL/$1?utm_source="$GH_ACTIONS; then
+        echo "Downloaded $1 from main URL"
+    # If main URL fails, try the backup URL
+    elif curl --compressed --retry 2 --output "$2" "$BACKUP_URL/$1?utm_source="$GH_ACTIONS; then
+        echo "Downloaded $1 from backup URL"
+    # If both URLs fail, return an error
+    else
+        echo "Failed to download $1 from both URLs"
+        return 1
+    fi
+}
 
-curl --compressed --retry 2 --output snyk-${PREFIX} "$BASE_URL/$VERSION/snyk-${PREFIX}" 
-curl --compressed --retry 2 --output snyk-${PREFIX}.sha256 "$BASE_URL/$VERSION/snyk-${PREFIX}.sha256"
+# Download Snyk binary
+if ! download_file "$VERSION/snyk-${PREFIX}" "snyk-${PREFIX}"; then
+    die "Failed to download Snyk binary"
+fi
 
+# Download SHA256 checksum file
+if ! download_file "$VERSION/snyk-${PREFIX}.sha256" "snyk-${PREFIX}.sha256"; then
+    die "Failed to download SHA256 file"
+fi
+
+# Verify the checksum
 sha256sum -c snyk-${PREFIX}.sha256
+
+# Make the binary executable
 chmod +x snyk-${PREFIX}
+
+# Move the binary to /usr/local/bin
 ${SUDO_CMD} mv snyk-${PREFIX} /usr/local/bin
 rm -rf snyk*


### PR DESCRIPTION
This PR changes the default download url to https://downloads.snyk.io/, adds a backup URL that uses https://static.sn/ yk.io, for downloading the Snyk CLI

Changes
- Changed base URL (https://downloads.snyk.io/cli)
- Added a backup URL (https://static.snyk.io/cli) to fall back on if the main URL fails
- Implemented a download_file function that attempts to download from the main URL first, then the backup URL if needed
- Updated the download process for both the Snyk binary and its SHA256 checksum file to use this new function

Testing
Tested the script to ensure:

- Successful downloads from the main URL
- Fallback to the backup URL when the main URL fails
- Proper error handling if both URLs fail
- Please review and test in your environment to ensure it meets our reliability standards.