### PR TITLE
chore: add better logging to setup action script

### DIFF
--- a/setup/setup_snyk.sh
+++ b/setup/setup_snyk.sh
@@ -67,7 +67,7 @@ ${SUDO_CMD} mv snyk /usr/local/bin
 #   $2: Output file name
 download_file() {
     echo_with_timestamp "Downloading Snyk binary"
-    if curl -D - --compressed --retry 2 --output "$2" "$1/$2?utm_source="$GH_ACTIONS; then
+    if curl --fail -D - --compressed --retry 2 --output "$2" "$1/$2?utm_source="$GH_ACTIONS; then
         echo_with_timestamp "Downloaded from $1/$2?utm_source=$GH_ACTIONS"
     else
         echo_with_timestamp "Failed to download from $1/$2?utm_source=$GH_ACTIONS"
@@ -75,7 +75,7 @@ download_file() {
     fi
 
     echo_with_timestamp "Downloading Snyk binary shasum"
-    if curl -D - --compressed --retry 2 --output "$2.sha256" "$1/$2.sha256?utm_source="$GH_ACTIONS; then
+    if curl --fail -D - --compressed --retry 2 --output "$2.sha256" "$1/$2.sha256?utm_source="$GH_ACTIONS; then
         echo_with_timestamp "Downloaded from $1/$2.sha256?utm_source=$GH_ACTIONS"
     else
         echo_with_timestamp "Failed to download from $1/$2.sha256?utm_source=$GH_ACTIONS"

--- a/setup/setup_snyk.sh
+++ b/setup/setup_snyk.sh
@@ -14,8 +14,12 @@ set -e
 #     ./snyk-setup.sh latest Linux
 #
 
+echo_with_timestamp() {
+    echo "$(date +%Y-%m-%dT%H:%M:%SZ) $1"
+}
+
 die () {
-    echo >&2 "$@"
+    echo_with_timestamp >&2 "$@"
     exit 1
 }
 
@@ -23,7 +27,7 @@ die () {
 [ "$#" -eq 2 ] || die "Setup Snyk requires two arguments, $# provided"
 
 cd "$(mktemp -d)"
-echo "Installing the $1 version of Snyk on $2"
+echo_with_timestamp "Installing the $1 version of Snyk on $2"
 
 VERSION=$1
 MAIN_URL="https://downloads.snyk.io/cli"
@@ -41,18 +45,18 @@ case "$2" in
 esac
 
 {
-    echo "#!/bin/bash"
-    echo export SNYK_INTEGRATION_NAME=\"$GH_ACTIONS\"
-    echo export SNYK_INTEGRATION_VERSION=\"setup \(${2}\)\"
-    echo export FORCE_COLOR=2
-    echo eval snyk-${PREFIX} \$@
+    echo_with_timestamp "#!/bin/bash"
+    echo_with_timestamp export SNYK_INTEGRATION_NAME=\"$GH_ACTIONS\"
+    echo_with_timestamp export SNYK_INTEGRATION_VERSION=\"setup \(${2}\)\"
+    echo_with_timestamp export FORCE_COLOR=2
+    echo_with_timestamp eval snyk-${PREFIX} \$@
 } > snyk
 
 if ! command -v "$SUDO_CMD" &> /dev/null; then
-  echo "$SUDO_CMD is NOT installed. Trying without sudo, expecting privileges to write to '/usr/local/bin'."
+  echo_with_timestamp "$SUDO_CMD is NOT installed. Trying without sudo, expecting privileges to write to '/usr/local/bin'."
   SUDO_CMD=""
 else
-    echo "$SUDO_CMD is installed."
+    echo_with_timestamp "$SUDO_CMD is installed."
 fi
 
 chmod +x snyk
@@ -64,33 +68,46 @@ ${SUDO_CMD} mv snyk /usr/local/bin
 download_file() {
     # Try to download from the main URL
     if curl --compressed --retry 2 --output "$2" "$MAIN_URL/$1?utm_source="$GH_ACTIONS; then
-        echo "Downloaded from $MAIN_URL/$1"
+        echo_with_timestamp "Downloaded from $MAIN_URL/$1?utm_source=$GH_ACTIONS"
     # If main URL fails, try the backup URL
     elif curl --compressed --retry 2 --output "$2" "$BACKUP_URL/$1?utm_source="$GH_ACTIONS; then
-        echo "Downloaded from $BACKUP_URL/$1"
+        echo_with_timestamp "Downloaded from $BACKUP_URL/$1?utm_source=$GH_ACTIONS"
     # If both URLs fail, return an error
     else
-        echo "Failed to download $1 from both URLs"
+        echo_with_timestamp "Failed to download $1 from both URLs"
         return 1
     fi
 }
 
-# Download Snyk binary
+echo_with_timestamp "Download Snyk binary"
 if ! download_file "$VERSION/snyk-${PREFIX}" "snyk-${PREFIX}"; then
     die "Failed to download Snyk binary"
 fi
 
-# Download SHA256 checksum file
+echo_with_timestamp "Download SHA256 checksum file"
 if ! download_file "$VERSION/snyk-${PREFIX}.sha256" "snyk-${PREFIX}.sha256"; then
     die "Failed to download SHA256 file"
 fi
 
 # Verify the checksum
-sha256sum -c snyk-${PREFIX}.sha256
+echo_with_timestamp "Validating shasum"
+if ! sha256sum -c snyk-${PREFIX}.sha256; then
+    echo_with_timestamp "Actual: "
+    sha256sum snyk-${PREFIX}
 
+    echo_with_timestamp "Expected: "
+    cat snyk-${PREFIX}.sha256
+
+    die "Shasum validation failed"
+fi
+
+
+echo_with_timestamp "Moving and cleaning files"
 # Make the binary executable
 chmod +x snyk-${PREFIX}
 
 # Move the binary to /usr/local/bin
 ${SUDO_CMD} mv snyk-${PREFIX} /usr/local/bin
 rm -rf snyk*
+
+echo_with_timestamp "Finished"

--- a/setup/setup_snyk.sh
+++ b/setup/setup_snyk.sh
@@ -67,7 +67,7 @@ ${SUDO_CMD} mv snyk /usr/local/bin
 #   $2: Output file name
 download_file() {
     echo_with_timestamp "Downloading Snyk binary"
-    if curl --compressed --retry 2 --output "$2" "$1/$2?utm_source="$GH_ACTIONS; then
+    if curl -D - --compressed --retry 2 --output "$2" "$1/$2?utm_source="$GH_ACTIONS; then
         echo_with_timestamp "Downloaded from $1/$2?utm_source=$GH_ACTIONS"
     else
         echo_with_timestamp "Failed to download from $1/$2?utm_source=$GH_ACTIONS"
@@ -75,7 +75,7 @@ download_file() {
     fi
 
     echo_with_timestamp "Downloading Snyk binary shasum"
-    if curl --compressed --retry 2 --output "$2.sha256" "$1/$2.sha256?utm_source="$GH_ACTIONS; then
+    if curl -D - --compressed --retry 2 --output "$2.sha256" "$1/$2.sha256?utm_source="$GH_ACTIONS; then
         echo_with_timestamp "Downloaded from $1/$2.sha256?utm_source=$GH_ACTIONS"
     else
         echo_with_timestamp "Failed to download from $1/$2.sha256?utm_source=$GH_ACTIONS"


### PR DESCRIPTION
This PR should
- add timestamps to log output
- output expected and actual shasums when validation fails
- download binary and shasum from the same URL before retrying with backup URL
- fails download on any 400+ status code