### PR TITLE
Mitigate script injection attack in snyk/actions/setup

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -18,11 +18,14 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - run: |
+    - env:
+        INPUT_SNYK_VERSION: ${{ inputs.snyk-version }}
+        INPUT_OS: ${{ inputs.os }}
+      run: |
         echo $GITHUB_ACTION_PATH
         echo ${{ github.action_path }}
         
-        ${{ github.action_path }}/setup_snyk.sh ${{ inputs.snyk-version }} ${{ inputs.os }} || $GITHUB_ACTION_PATH/setup_snyk.sh ${{ inputs.snyk-version }} ${{ inputs.os }}
+        ${{ github.action_path }}/setup_snyk.sh "${INPUT_SNYK_VERSION}" "${INPUT_OS}" || $GITHUB_ACTION_PATH/setup_snyk.sh "${INPUT_SNYK_VERSION}" "${INPUT_OS}"
       shell: bash
     - id: version
       shell: bash


### PR DESCRIPTION
It is possible to perform script injection via inputs in `snyk/actions/setup` GitHub Action. This fix mitigates it. More details [here](https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).