### PR TITLE
Bump gitleaks pre-commit hook from 8.17.0 to 8.27.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,6 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.17.0
+    rev: v8.27.2
     hooks:
       - id: gitleaks


### PR DESCRIPTION
Bumping gitleaks pre-commit hook from 8.17.0 to 8.27.2 by `pre-commit autoupdate` command.