### PR TITLE
chore: update READMES with non-deprecated actions

### DIFF
--- a/_templates/README.md.erb
+++ b/_templates/README.md.erb
@@ -69,6 +69,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -79,7 +81,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/cocoapods/README.md
+++ b/cocoapods/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,47 +6,47 @@ vulnerabilities in your Docker images.
 You can use the Action as follows:
 
 ```yaml
-name: Example workflow for Docker using Snyk 
+name: Example workflow for Docker using Snyk
 on: push
 jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - name: Run Snyk to check Docker image for vulnerabilities
-      uses: snyk/actions/docker@master
-      env:
-        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      with:
-        image: your/image-to-test
+      - name: Run Snyk to check Docker image for vulnerabilities
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: your/image-to-test
 ```
 
 The Snyk Docker Action has properties which are passed to the underlying image. These are
 passed to the action using `with`.
 
-| Property | Default | Description |
-| --- | --- | --- |
-| args |   | Override the default arguments to the Snyk image |
-| command | test | Specifiy which command to run, for instance test or monitor |
-| image |    | The name of the image to test |
-| json | false | In addition to the stdout, save the results as snyk.json |
-| sarif | true | In addition to the stdout, save the results as snyk.sarif |
+| Property | Default | Description                                                 |
+| -------- | ------- | ----------------------------------------------------------- |
+| args     |         | Override the default arguments to the Snyk image            |
+| command  | test    | Specifiy which command to run, for instance test or monitor |
+| image    |         | The name of the image to test                               |
+| json     | false   | In addition to the stdout, save the results as snyk.json    |
+| sarif    | true    | In addition to the stdout, save the results as snyk.sarif   |
 
 For example, you can choose to only report on high severity vulnerabilities.
 
 ```yaml
-name: Example workflow for Docker using Snyk 
+name: Example workflow for Docker using Snyk
 on: push
 jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - name: Run Snyk to check Docker images for vulnerabilities
-      uses: snyk/actions/docker@master
-      env:
-        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      with:
-        image: your/image-to-test
-        args: --severity-threshold=high
+      - name: Run Snyk to check Docker images for vulnerabilities
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: your/image-to-test
+          args: --severity-threshold=high
 ```
 
 The Docker Action also supports integrating with GitHub Code Scanning and can show issues in the GitHub Security tab. As long as you reference a Dockerfile with `--file=Dockerfile` then a `snyk.sarif` file will be generated which can be uploaded to GitHub Code Scanning.
@@ -59,25 +59,27 @@ on: push
 jobs:
   snyk:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
-    - uses: actions/checkout@v2
-    - name: Build a Docker image
-      run: docker build -t your/image-to-test .
-    - name: Run Snyk to check Docker image for vulnerabilities
-      # Snyk can be used to break the build when it detects vulnerabilities.
-      # In this case we want to upload the issues to GitHub Code Scanning
-      continue-on-error: true
-      uses: snyk/actions/docker@master
-      env:
-        # In order to use the Snyk Action you will need to have a Snyk API token.
-        # More details in https://github.com/snyk/actions#getting-your-snyk-token
-        # or you can signup for free at https://snyk.io/login
-        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      with:
-        image: your/image-to-test
-        args: --file=Dockerfile
-    - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v2
-      with:
-        sarif_file: snyk.sarif
+      - uses: actions/checkout@master
+      - name: Build a Docker image
+        run: docker build -t your/image-to-test .
+      - name: Run Snyk to check Docker image for vulnerabilities
+        # Snyk can be used to break the build when it detects vulnerabilities.
+        # In this case we want to upload the issues to GitHub Code Scanning
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          # In order to use the Snyk Action you will need to have a Snyk API token.
+          # More details in https://github.com/snyk/actions#getting-your-snyk-token
+          # or you can signup for free at https://snyk.io/login
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: your/image-to-test
+          args: --file=Dockerfile
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk.sarif
 ```

--- a/docker/example.yml
+++ b/docker/example.yml
@@ -11,8 +11,10 @@ on: push
 jobs:
   snyk:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
     - name: Build a Docker image
       run: docker build -t your/image-to-test .
     - name: Run Snyk to check Docker image for vulnerabilities
@@ -29,6 +31,6 @@ jobs:
         image: your/image-to-test
         args: --file=Dockerfile
     - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: snyk.sarif

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/golang/README.md
+++ b/golang/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk11/README.md
+++ b/gradle-jdk11/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk12/README.md
+++ b/gradle-jdk12/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk14/README.md
+++ b/gradle-jdk14/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk16/README.md
+++ b/gradle-jdk16/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk17/README.md
+++ b/gradle-jdk17/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk21/README.md
+++ b/gradle-jdk21/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/iac/README.md
+++ b/iac/README.md
@@ -12,22 +12,21 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
       - name: Run Snyk to check Kubernetes manifest file for issues
         uses: snyk/actions/iac@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
 
-In order to use the Snyk Infrastructure as Code Test Action, you will need to have a Snyk API token. 
-More details in [Getting Your Snyk Token](https://github.com/snyk/actions#getting-your-snyk-token), or you can [sign up for free](https://snyk.io/login).  
-
+In order to use the Snyk Infrastructure as Code Test Action, you will need to have a Snyk API token.
+More details in [Getting Your Snyk Token](https://github.com/snyk/actions#getting-your-snyk-token), or you can [sign up for free](https://snyk.io/login).
 
 The Snyk Infrastructure as Code Action has properties which are passed to the underlying image. These are
 passed to the action using `with`:
 
-| Property  | Default | Description                                                        |
-|-----------|----------|-------------------------------------------------------------------|
+| Property  | Default  | Description                                                       |
+| --------- | -------- | ----------------------------------------------------------------- |
 | `args`    |          | Override the default arguments to the Snyk image.                 |
 | `command` | `"test"` | Specify which command to run, currently only `test` is supported. |
 | `file`    |          | The paths in which to scan files with issues.                     |
@@ -35,7 +34,9 @@ passed to the action using `with`:
 | `sarif`   | `true`   | In addition to the stdout, save the results as snyk.sarif         |
 
 ## Examples
+
 ### Specifying paths
+
 You can specify the paths to the configuration files and directories to target during the test.  
 When no path is specified, the whole repository is scanned by default:
 
@@ -46,7 +47,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
       - name: Run Snyk to check Kubernetes manifest file for issues
         uses: snyk/actions/iac@master
         env:
@@ -56,6 +57,7 @@ jobs:
 ```
 
 ### Specifying severity threshold
+
 You can also choose to only report on high severity vulnerabilities:
 
 ```yaml
@@ -65,7 +67,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
       - name: Run Snyk to check Kubernetes manifest file for issues
         uses: snyk/actions/iac@master
         env:
@@ -74,7 +76,9 @@ jobs:
           file: your/kubernetes-manifest.yaml
           args: --severity-threshold=high
 ```
+
 ### Sharing test results
+
 You can [share your test results](https://docs.snyk.io/products/snyk-infrastructure-as-code/share-cli-results-with-the-snyk-web-ui) to the Snyk platform:
 
 ```yaml
@@ -84,7 +88,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
       - name: Run Snyk to check Kubernetes manifest file for issues
         uses: snyk/actions/iac@master
         env:
@@ -92,7 +96,9 @@ jobs:
         with:
           args: --report
 ```
+
 ### Specifying scan mode for Terraform Plan
+
 You can also choose the [scan mode](https://docs.snyk.io/products/snyk-infrastructure-as-code/snyk-cli-for-infrastructure-as-code/test-your-terraform-files-with-the-cli-tool#terraform-plan), when scanning Terraform Plan files:
 
 ```yaml
@@ -102,7 +108,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
       - name: Run Snyk to check Kubernetes manifest file for issues
         uses: snyk/actions/iac@master
         env:
@@ -121,8 +127,10 @@ on: push
 jobs:
   snyk:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
       - name: Run Snyk to check configuration files for security issues
         # Snyk can be used to break the build when it detects security issues.
         # In this case we want to upload the issues to GitHub Code Scanning
@@ -131,12 +139,14 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```
 
 ## Related Documentation
-For more information on how to use the `snyk iac test` command, see the following: 
+
+For more information on how to use the `snyk iac test` command, see the following:
+
 - [Snyk CLI for Infastructure as Code](https://docs.snyk.io/products/snyk-infrastructure-as-code/snyk-cli-for-infrastructure-as-code)
 - [Snyk Infrastructure as Code Test Command](https://docs.snyk.io/snyk-cli/commands/iac-test)

--- a/iac/example.yml
+++ b/iac/example.yml
@@ -10,8 +10,10 @@ on: push
 jobs:
   snyk:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
       - name: Run Snyk to check configuration files for security issues
         # Snyk can be used to break the build when it detects security issues.
         # In this case we want to upload the issues to GitHub Code Scanning
@@ -29,6 +31,6 @@ jobs:
         # with:
           # file: your-file-to-test.yaml
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif

--- a/maven-3-jdk-11/README.md
+++ b/maven-3-jdk-11/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-17/README.md
+++ b/maven-3-jdk-17/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-20/README.md
+++ b/maven-3-jdk-20/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-21/README.md
+++ b/maven-3-jdk-21/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-22/README.md
+++ b/maven-3-jdk-22/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven/README.md
+++ b/maven/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/node/README.md
+++ b/node/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/php/README.md
+++ b/php/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.10/README.md
+++ b/python-3.10/README.md
@@ -69,6 +69,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -79,7 +81,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.11/README.md
+++ b/python-3.11/README.md
@@ -69,6 +69,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -79,7 +81,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.6/README.md
+++ b/python-3.6/README.md
@@ -69,6 +69,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -79,7 +81,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.7/README.md
+++ b/python-3.7/README.md
@@ -69,6 +69,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -79,7 +81,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.8/README.md
+++ b/python-3.8/README.md
@@ -69,6 +69,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -79,7 +81,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.9/README.md
+++ b/python-3.9/README.md
@@ -69,6 +69,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -79,7 +81,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -69,6 +69,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -79,7 +81,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/sbt1.10.0-scala3.4.2/README.md
+++ b/sbt1.10.0-scala3.4.2/README.md
@@ -62,6 +62,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,7 +74,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/scala/README.md
+++ b/scala/README.md
@@ -3,7 +3,6 @@
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Scala projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-
 You can use the Action as follows:
 
 ```yaml
@@ -62,6 +61,8 @@ on: push
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -72,12 +73,12 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```
 
 Made with 💜 by Snyk
 
-[cli-gh]: https://github.com/snyk/snyk 'Snyk CLI'
-[cli-ref]: https://docs.snyk.io/snyk-cli/cli-reference 'Snyk CLI Reference documentation'
+[cli-gh]: https://github.com/snyk/snyk "Snyk CLI"
+[cli-ref]: https://docs.snyk.io/snyk-cli/cli-reference "Snyk CLI Reference documentation"


### PR DESCRIPTION
I didn’t make any changes to the core code, I just fixed READMEs because the checkout action was not aligned everywhere and the github/codeql-action/upload-sarif@v2 action is now deprecated and does not work anymore.