### PR TITLE
fix: update `upload-sarif` documentation

### DIFF
--- a/_templates/README.md.erb
+++ b/_templates/README.md.erb
@@ -71,10 +71,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for <%= @name %> using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -85,7 +96,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/cocoapods/README.md
+++ b/cocoapods/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for CocoaPods using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for dotNET using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/elixir-1.18/README.md
+++ b/elixir-1.18/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for elixir using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/golang/README.md
+++ b/golang/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Golang using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-8-jdk17/README.md
+++ b/gradle-8-jdk17/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-8-jdk21/README.md
+++ b/gradle-8-jdk21/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-8-jdk24/README.md
+++ b/gradle-8-jdk24/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-9-jdk17/README.md
+++ b/gradle-9-jdk17/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-9-jdk21/README.md
+++ b/gradle-9-jdk21/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-9-jdk24/README.md
+++ b/gradle-9-jdk24/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk11/README.md
+++ b/gradle-jdk11/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk12/README.md
+++ b/gradle-jdk12/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk14/README.md
+++ b/gradle-jdk14/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk16/README.md
+++ b/gradle-jdk16/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk17/README.md
+++ b/gradle-jdk17/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk21/README.md
+++ b/gradle-jdk21/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-11/README.md
+++ b/maven-3-jdk-11/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-17/README.md
+++ b/maven-3-jdk-17/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-20/README.md
+++ b/maven-3-jdk-20/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-21/README.md
+++ b/maven-3-jdk-21/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-22/README.md
+++ b/maven-3-jdk-22/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-24/README.md
+++ b/maven-3-jdk-24/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven/README.md
+++ b/maven/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/node/README.md
+++ b/node/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Node using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/php/README.md
+++ b/php/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for PHP using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.10/README.md
+++ b/python-3.10/README.md
@@ -70,10 +70,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -84,7 +95,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.11/README.md
+++ b/python-3.11/README.md
@@ -70,10 +70,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -84,7 +95,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.12/README.md
+++ b/python-3.12/README.md
@@ -70,10 +70,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -84,7 +95,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.6/README.md
+++ b/python-3.6/README.md
@@ -71,10 +71,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -85,7 +96,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.7/README.md
+++ b/python-3.7/README.md
@@ -71,10 +71,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -85,7 +96,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.8/README.md
+++ b/python-3.8/README.md
@@ -71,10 +71,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -85,7 +96,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.9/README.md
+++ b/python-3.9/README.md
@@ -70,10 +70,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -84,7 +95,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -70,10 +70,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -84,7 +95,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Ruby using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/sbt1.10.0-scala3.4.2/README.md
+++ b/sbt1.10.0-scala3.4.2/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for SBT1.10.0 using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/scala/README.md
+++ b/scala/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Scala using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```


### PR DESCRIPTION
After the [deprecation](https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/) of `v2` of the `upload-sarif` action, we need to update our documentation to reflect the same change.