### PR TITLE
chore(ci): intentionally empty commit to trigger release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
 
             - name: Get next version with semver-action
               id: semver
-              uses: ietf-tools/semver-action@v1
+              uses: ietf-tools/semver-action@000ddb2ebacad350ff2a15382a344dc05ea4c0a4
               with:
                 branch: main
                 token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The previous Release action failed as I had not allow listed the action to be run for this repo.
https://github.com/snyk/actions/actions/runs/18188257192