### PR TITLE
docs: update usage instructions

### DIFF
--- a/_templates/README.md.erb
+++ b/_templates/README.md.erb
@@ -17,7 +17,7 @@ vulnerabilities in your <%= @variant %> projects. This Action is based on the [S
                           >
                           > If manifest files are present under any location other root then they MUST be installed prior to running Snyk.
 <% end %>
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for <%= @name %> using Snyk
@@ -26,12 +26,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/<%= @variant.downcase %>@master
+        uses: snyk/actions/<%= @variant.downcase %>@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/<%= @variant.downcase %>@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -52,9 +62,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/<%= @variant.downcase %>@master
+        uses: snyk/actions/<%= @variant.downcase %>@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -87,9 +97,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/<%= @variant.downcase %>@master
+        uses: snyk/actions/<%= @variant.downcase %>@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/cocoapods/README.md
+++ b/cocoapods/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your CocoaPods projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for CocoaPods using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/cocoapods@master
+        uses: snyk/actions/cocoapods@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/cocoapods@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/cocoapods@master
+        uses: snyk/actions/cocoapods@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/cocoapods@master
+        uses: snyk/actions/cocoapods@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -10,7 +10,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your dotNET projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for dotNET using Snyk
@@ -19,12 +19,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/dotnet@master
+        uses: snyk/actions/dotnet@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/dotnet@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -45,9 +55,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/dotnet@master
+        uses: snyk/actions/dotnet@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -80,9 +90,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/dotnet@master
+        uses: snyk/actions/dotnet@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/elixir-1.18/README.md
+++ b/elixir-1.18/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your elixir-1.18 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for elixir using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/elixir-1.18@master
+        uses: snyk/actions/elixir-1.18@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/elixir-1.18@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/elixir-1.18@master
+        uses: snyk/actions/elixir-1.18@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/elixir-1.18@master
+        uses: snyk/actions/elixir-1.18@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/golang/README.md
+++ b/golang/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Golang projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Golang using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/golang@master
+        uses: snyk/actions/golang@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/golang@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/golang@master
+        uses: snyk/actions/golang@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/golang@master
+        uses: snyk/actions/golang@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle-8-jdk17/README.md
+++ b/gradle-8-jdk17/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your gradle-8-jdk17 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for gradle using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-8-jdk17@master
+        uses: snyk/actions/gradle-8-jdk17@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle-8-jdk17@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-8-jdk17@master
+        uses: snyk/actions/gradle-8-jdk17@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-8-jdk17@master
+        uses: snyk/actions/gradle-8-jdk17@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle-8-jdk21/README.md
+++ b/gradle-8-jdk21/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your gradle-8-jdk21 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for gradle using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-8-jdk21@master
+        uses: snyk/actions/gradle-8-jdk21@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle-8-jdk21@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-8-jdk21@master
+        uses: snyk/actions/gradle-8-jdk21@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-8-jdk21@master
+        uses: snyk/actions/gradle-8-jdk21@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle-8-jdk24/README.md
+++ b/gradle-8-jdk24/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your gradle-8-jdk24 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for gradle using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-8-jdk24@master
+        uses: snyk/actions/gradle-8-jdk24@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle-8-jdk24@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-8-jdk24@master
+        uses: snyk/actions/gradle-8-jdk24@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-8-jdk24@master
+        uses: snyk/actions/gradle-8-jdk24@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle-9-jdk17/README.md
+++ b/gradle-9-jdk17/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your gradle-9-jdk17 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for gradle using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-9-jdk17@master
+        uses: snyk/actions/gradle-9-jdk17@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle-9-jdk17@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-9-jdk17@master
+        uses: snyk/actions/gradle-9-jdk17@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-9-jdk17@master
+        uses: snyk/actions/gradle-9-jdk17@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle-9-jdk21/README.md
+++ b/gradle-9-jdk21/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your gradle-9-jdk21 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for gradle using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-9-jdk21@master
+        uses: snyk/actions/gradle-9-jdk21@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle-9-jdk21@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-9-jdk21@master
+        uses: snyk/actions/gradle-9-jdk21@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-9-jdk21@master
+        uses: snyk/actions/gradle-9-jdk21@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle-9-jdk24/README.md
+++ b/gradle-9-jdk24/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your gradle-9-jdk24 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for gradle using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-9-jdk24@master
+        uses: snyk/actions/gradle-9-jdk24@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle-9-jdk24@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-9-jdk24@master
+        uses: snyk/actions/gradle-9-jdk24@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-9-jdk24@master
+        uses: snyk/actions/gradle-9-jdk24@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle-jdk11/README.md
+++ b/gradle-jdk11/README.md
@@ -10,7 +10,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk11 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Gradle using Snyk
@@ -19,12 +19,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk11@master
+        uses: snyk/actions/gradle-jdk11@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle-jdk11@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -45,9 +55,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk11@master
+        uses: snyk/actions/gradle-jdk11@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -80,9 +90,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk11@master
+        uses: snyk/actions/gradle-jdk11@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle-jdk12/README.md
+++ b/gradle-jdk12/README.md
@@ -10,7 +10,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk12 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Gradle using Snyk
@@ -19,12 +19,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk12@master
+        uses: snyk/actions/gradle-jdk12@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle-jdk12@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -45,9 +55,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk12@master
+        uses: snyk/actions/gradle-jdk12@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -80,9 +90,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk12@master
+        uses: snyk/actions/gradle-jdk12@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle-jdk14/README.md
+++ b/gradle-jdk14/README.md
@@ -10,7 +10,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk14 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Gradle using Snyk
@@ -19,12 +19,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk14@master
+        uses: snyk/actions/gradle-jdk14@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle-jdk14@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -45,9 +55,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk14@master
+        uses: snyk/actions/gradle-jdk14@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -80,9 +90,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk14@master
+        uses: snyk/actions/gradle-jdk14@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle-jdk16/README.md
+++ b/gradle-jdk16/README.md
@@ -10,7 +10,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk16 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Gradle using Snyk
@@ -19,12 +19,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk16@master
+        uses: snyk/actions/gradle-jdk16@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle-jdk16@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -45,9 +55,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk16@master
+        uses: snyk/actions/gradle-jdk16@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -80,9 +90,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk16@master
+        uses: snyk/actions/gradle-jdk16@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle-jdk17/README.md
+++ b/gradle-jdk17/README.md
@@ -10,7 +10,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk17 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Gradle using Snyk
@@ -19,12 +19,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk17@master
+        uses: snyk/actions/gradle-jdk17@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle-jdk17@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -45,9 +55,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk17@master
+        uses: snyk/actions/gradle-jdk17@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -80,9 +90,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk17@master
+        uses: snyk/actions/gradle-jdk17@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle-jdk21/README.md
+++ b/gradle-jdk21/README.md
@@ -10,7 +10,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk21 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Gradle using Snyk
@@ -19,12 +19,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk21@master
+        uses: snyk/actions/gradle-jdk21@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle-jdk21@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -45,9 +55,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk21@master
+        uses: snyk/actions/gradle-jdk21@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -80,9 +90,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk21@master
+        uses: snyk/actions/gradle-jdk21@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Gradle using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle@master
+        uses: snyk/actions/gradle@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/gradle@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle@master
+        uses: snyk/actions/gradle@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle@master
+        uses: snyk/actions/gradle@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/maven-3-jdk-11/README.md
+++ b/maven-3-jdk-11/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Maven-3-jdk-11 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Maven using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-11@master
+        uses: snyk/actions/maven-3-jdk-11@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/maven-3-jdk-11@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-11@master
+        uses: snyk/actions/maven-3-jdk-11@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-11@master
+        uses: snyk/actions/maven-3-jdk-11@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/maven-3-jdk-17/README.md
+++ b/maven-3-jdk-17/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Maven-3-jdk-17 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Maven using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-17@master
+        uses: snyk/actions/maven-3-jdk-17@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/maven-3-jdk-17@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-17@master
+        uses: snyk/actions/maven-3-jdk-17@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-17@master
+        uses: snyk/actions/maven-3-jdk-17@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/maven-3-jdk-20/README.md
+++ b/maven-3-jdk-20/README.md
@@ -10,7 +10,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Maven-3-jdk-20 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Maven using Snyk
@@ -19,12 +19,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-20@master
+        uses: snyk/actions/maven-3-jdk-20@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/maven-3-jdk-20@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -45,9 +55,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-20@master
+        uses: snyk/actions/maven-3-jdk-20@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -80,9 +90,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-20@master
+        uses: snyk/actions/maven-3-jdk-20@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/maven-3-jdk-21/README.md
+++ b/maven-3-jdk-21/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Maven-3-jdk-21 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Maven using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-21@master
+        uses: snyk/actions/maven-3-jdk-21@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/maven-3-jdk-21@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-21@master
+        uses: snyk/actions/maven-3-jdk-21@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-21@master
+        uses: snyk/actions/maven-3-jdk-21@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/maven-3-jdk-22/README.md
+++ b/maven-3-jdk-22/README.md
@@ -10,7 +10,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Maven-3-jdk-22 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Maven using Snyk
@@ -19,12 +19,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-22@master
+        uses: snyk/actions/maven-3-jdk-22@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/maven-3-jdk-22@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -45,9 +55,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-22@master
+        uses: snyk/actions/maven-3-jdk-22@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -80,9 +90,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-22@master
+        uses: snyk/actions/maven-3-jdk-22@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/maven-3-jdk-24/README.md
+++ b/maven-3-jdk-24/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Maven-3-jdk-24 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Maven using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-24@master
+        uses: snyk/actions/maven-3-jdk-24@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/maven-3-jdk-24@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-24@master
+        uses: snyk/actions/maven-3-jdk-24@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven-3-jdk-24@master
+        uses: snyk/actions/maven-3-jdk-24@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/maven/README.md
+++ b/maven/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Maven projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Maven using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven@master
+        uses: snyk/actions/maven@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/maven@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven@master
+        uses: snyk/actions/maven@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven@master
+        uses: snyk/actions/maven@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/node/README.md
+++ b/node/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Node projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Node using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/node@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/php/README.md
+++ b/php/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your PHP projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for PHP using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/php@master
+        uses: snyk/actions/php@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/php@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/php@master
+        uses: snyk/actions/php@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/php@master
+        uses: snyk/actions/php@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/python-3.10/README.md
+++ b/python-3.10/README.md
@@ -16,7 +16,7 @@ vulnerabilities in your Python-3.10 projects. This Action is based on the [Snyk 
                           >
                           > If manifest files are present under any location other root then they MUST be installed prior to running Snyk.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Python using Snyk
@@ -25,12 +25,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.10@master
+        uses: snyk/actions/python-3.10@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/python-3.10@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -51,9 +61,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.10@master
+        uses: snyk/actions/python-3.10@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -86,9 +96,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.10@master
+        uses: snyk/actions/python-3.10@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/python-3.11/README.md
+++ b/python-3.11/README.md
@@ -16,7 +16,7 @@ vulnerabilities in your Python-3.11 projects. This Action is based on the [Snyk 
                           >
                           > If manifest files are present under any location other root then they MUST be installed prior to running Snyk.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Python using Snyk
@@ -25,12 +25,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.11@master
+        uses: snyk/actions/python-3.11@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/python-3.11@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -51,9 +61,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.11@master
+        uses: snyk/actions/python-3.11@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -86,9 +96,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.11@master
+        uses: snyk/actions/python-3.11@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/python-3.12/README.md
+++ b/python-3.12/README.md
@@ -16,7 +16,7 @@ vulnerabilities in your Python-3.12 projects. This Action is based on the [Snyk 
                           >
                           > If manifest files are present under any location other root then they MUST be installed prior to running Snyk.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Python using Snyk
@@ -25,12 +25,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.12@master
+        uses: snyk/actions/python-3.12@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/python-3.12@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -51,9 +61,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.12@master
+        uses: snyk/actions/python-3.12@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -86,9 +96,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.12@master
+        uses: snyk/actions/python-3.12@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/python-3.6/README.md
+++ b/python-3.6/README.md
@@ -17,7 +17,7 @@ vulnerabilities in your Python-3.6 projects. This Action is based on the [Snyk C
                           >
                           > If manifest files are present under any location other root then they MUST be installed prior to running Snyk.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Python using Snyk
@@ -26,12 +26,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.6@master
+        uses: snyk/actions/python-3.6@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/python-3.6@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -52,9 +62,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.6@master
+        uses: snyk/actions/python-3.6@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -87,9 +97,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.6@master
+        uses: snyk/actions/python-3.6@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/python-3.7/README.md
+++ b/python-3.7/README.md
@@ -17,7 +17,7 @@ vulnerabilities in your Python-3.7 projects. This Action is based on the [Snyk C
                           >
                           > If manifest files are present under any location other root then they MUST be installed prior to running Snyk.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Python using Snyk
@@ -26,12 +26,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.7@master
+        uses: snyk/actions/python-3.7@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/python-3.7@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -52,9 +62,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.7@master
+        uses: snyk/actions/python-3.7@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -87,9 +97,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.7@master
+        uses: snyk/actions/python-3.7@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/python-3.8/README.md
+++ b/python-3.8/README.md
@@ -17,7 +17,7 @@ vulnerabilities in your Python-3.8 projects. This Action is based on the [Snyk C
                           >
                           > If manifest files are present under any location other root then they MUST be installed prior to running Snyk.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Python using Snyk
@@ -26,12 +26,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.8@master
+        uses: snyk/actions/python-3.8@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/python-3.8@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -52,9 +62,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.8@master
+        uses: snyk/actions/python-3.8@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -87,9 +97,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.8@master
+        uses: snyk/actions/python-3.8@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/python-3.9/README.md
+++ b/python-3.9/README.md
@@ -16,7 +16,7 @@ vulnerabilities in your Python-3.9 projects. This Action is based on the [Snyk C
                           >
                           > If manifest files are present under any location other root then they MUST be installed prior to running Snyk.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Python using Snyk
@@ -25,12 +25,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.9@master
+        uses: snyk/actions/python-3.9@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/python-3.9@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -51,9 +61,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.9@master
+        uses: snyk/actions/python-3.9@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -86,9 +96,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.9@master
+        uses: snyk/actions/python-3.9@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/python/README.md
+++ b/python/README.md
@@ -16,7 +16,7 @@ vulnerabilities in your Python projects. This Action is based on the [Snyk CLI][
                           >
                           > If manifest files are present under any location other root then they MUST be installed prior to running Snyk.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Python using Snyk
@@ -25,12 +25,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python@master
+        uses: snyk/actions/python@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/python@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -51,9 +61,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python@master
+        uses: snyk/actions/python@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -86,9 +96,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python@master
+        uses: snyk/actions/python@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Ruby projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Ruby using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/ruby@master
+        uses: snyk/actions/ruby@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/ruby@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/ruby@master
+        uses: snyk/actions/ruby@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/ruby@master
+        uses: snyk/actions/ruby@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/sbt1.10.0-scala3.4.2/README.md
+++ b/sbt1.10.0-scala3.4.2/README.md
@@ -9,7 +9,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your SBT1.10.0-Scala3.4.2 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for SBT1.10.0 using Snyk
@@ -18,12 +18,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/sbt1.10.0-scala3.4.2@master
+        uses: snyk/actions/sbt1.10.0-scala3.4.2@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/sbt1.10.0-scala3.4.2@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -44,9 +54,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/sbt1.10.0-scala3.4.2@master
+        uses: snyk/actions/sbt1.10.0-scala3.4.2@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -79,9 +89,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/sbt1.10.0-scala3.4.2@master
+        uses: snyk/actions/sbt1.10.0-scala3.4.2@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/scala/README.md
+++ b/scala/README.md
@@ -10,7 +10,7 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Scala projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.
 
-You can use the Action as follows:
+You can use the Action as follows (recommended: pin to major version):
 
 ```yaml
 name: Example workflow for Scala using Snyk
@@ -19,12 +19,22 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/scala@master
+        uses: snyk/actions/scala@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
+
+## Alternative: Pin to Commit SHA
+
+For maximum security, pin actions to a full commit SHA. Unlike tags or releases, a SHA is immutable and guarantees the exact code version used.
+
+```yaml
+- uses: snyk/actions/scala@<commit-sha>
+```
+
+> **Note:** Git tags and release tags can be moved or recreated, so they are not truly immutable. Pinning to a commit SHA is the most secure pattern.
 
 ## Properties
 
@@ -45,9 +55,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/scala@master
+        uses: snyk/actions/scala@v1
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -80,9 +90,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/scala@master
+        uses: snyk/actions/scala@v1
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
This is a proposal at the moment, the documentation here is for a v1 of the action which does not yet exist. That should be published before these changes can be released. 

Blocked by: https://github.com/snyk/actions/pull/201