### PR TITLE
chore(ci): adjust to build release based on current branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@ name: Release
 on:
     push:
         branches:
-            - main
             - master
 
 jobs:
@@ -20,7 +19,7 @@ jobs:
               id: semver
               uses: ietf-tools/semver-action@000ddb2ebacad350ff2a15382a344dc05ea4c0a4
               with:
-                branch: main
+                branch: ${{ github.ref_name }}	
                 token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Create tag


### PR DESCRIPTION
At the moment our default branch is `master`, in the future we will move to `main` to align with our other repositories.

This change makes the workflow more flexible to that future change and fixes the current failure.

Ref: https://snyksec.atlassian.net/browse/CLI-801