### PR TITLE
Cache Snyk CLI setup

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -41,6 +41,13 @@ The Action also has outputs:
 |----------|---------|--------------------------------------------|
 | version  |         | The full version of the Snyk CLI installed |
 
+## Caching
+
+The Setup Action automatically caches the Snyk CLI binary to speed up subsequent workflow runs. The cache key is based on the operating system and Snyk version (`snyk-{os}-{version}`).
+
+> [!IMPORTANT]
+> The Snyk CLI is only cached when using a specific version of Snyk (e.g., `v1.391.0`). When using `snyk-version: latest`, the CLI will always be re-downloaded to ensure you have the most recent version.
+
 For example, you can choose to install a specific version of Snyk. The installed version can be
 grabbed from the output:
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -31,15 +31,15 @@ The Setup Action requires `bash` and `curl` to be available and requires privile
 The Snyk Setup Action has properties which are passed to the underlying image. These are
 passed to the action using `with`.
 
-| Property | Default | Description |
-| --- | --- | --- |
-| snyk-version | latest | Install a specific version of Snyk |
+| Property     | Default | Description                        |
+|--------------|---------|------------------------------------|
+| snyk-version | latest  | Install a specific version of Snyk |
 
 The Action also has outputs:
 
-| Property | Default | Description |
-| --- | --- | --- |
-| version |   | The full version of the Snyk CLI installed |
+| Property | Default | Description                                |
+|----------|---------|--------------------------------------------|
+| version  |         | The full version of the Snyk CLI installed |
 
 For example, you can choose to install a specific version of Snyk. The installed version can be
 grabbed from the output:

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -22,7 +22,9 @@ runs:
       id: cache-snyk
       uses: actions/cache@v4
       with:
-        path: /usr/local/bin/snyk
+        path: |
+          /usr/local/bin/snyk
+          /usr/local/bin/snyk-*
         key: snyk-${{ inputs.os }}-${{ inputs.snyk-version }}
 
     - name: Install Snyk CLI

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -18,15 +18,23 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - env:
+    - name: Cache Snyk CLI
+      id: cache-snyk
+      uses: actions/cache@v4
+      with:
+        path: /usr/local/bin/snyk
+        key: snyk-${{ inputs.os }}-${{ inputs.snyk-version }}
+
+    - name: Install Snyk CLI
+      if: inputs.snyk-version == 'latest' || steps.cache-snyk.outputs.cache-hit != 'true'
+      shell: bash
+      env:
         INPUT_SNYK_VERSION: ${{ inputs.snyk-version }}
         INPUT_OS: ${{ inputs.os }}
       run: |
-        echo $GITHUB_ACTION_PATH
-        echo ${{ github.action_path }}
-        
         ${{ github.action_path }}/setup_snyk.sh "${INPUT_SNYK_VERSION}" "${INPUT_OS}" || $GITHUB_ACTION_PATH/setup_snyk.sh "${INPUT_SNYK_VERSION}" "${INPUT_OS}"
+
+    - name: Get Snyk version
+      id: version
       shell: bash
-    - id: version
-      shell: bash
-      run: echo "version=$(snyk version)" >> $GITHUB_OUTPUT
+      run: echo "version=$(snyk version)" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Cache the Snyk CLI so it doesn't have to be downloaded each time if the Snyk version is set.

- Uses the Snyk Version as the cache key
- If the version is `latest` will always download as can't be certain that it hasn't changed