### PR TITLE
feat(setup): add arm64 support and runner.arch input

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -11,6 +11,9 @@ inputs:
   os:
     description: "Which Operating System Snyk will run on"
     default: ${{ runner.os }}
+  arch:
+    description: "Which CPU architecture Snyk will run on (e.g. X64, ARM64). Defaults to the runner architecture."
+    default: ${{ runner.arch }}
 outputs:
   version:
     description: "The version of Snyk installed"
@@ -21,11 +24,12 @@ runs:
     - env:
         INPUT_SNYK_VERSION: ${{ inputs.snyk-version }}
         INPUT_OS: ${{ inputs.os }}
+        INPUT_ARCH: ${{ inputs.arch }}
       run: |
         echo $GITHUB_ACTION_PATH
         echo ${{ github.action_path }}
-        
-        ${{ github.action_path }}/setup_snyk.sh "${INPUT_SNYK_VERSION}" "${INPUT_OS}" || $GITHUB_ACTION_PATH/setup_snyk.sh "${INPUT_SNYK_VERSION}" "${INPUT_OS}"
+
+        ${{ github.action_path }}/setup_snyk.sh "${INPUT_SNYK_VERSION}" "${INPUT_OS}" "${INPUT_ARCH}" || $GITHUB_ACTION_PATH/setup_snyk.sh "${INPUT_SNYK_VERSION}" "${INPUT_OS}" "${INPUT_ARCH}"
       shell: bash
     - id: version
       shell: bash

--- a/setup/setup_snyk.sh
+++ b/setup/setup_snyk.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
 set -e
 
-# This script takes two positional arguments. The first is the version of Snyk to install.
-# This can be a standard version (ie. v1.390.0) or it can be latest, in which case the
-# latest released version will be used.
+# This script takes two or three positional arguments. The first is the version
+# of Snyk to install. This can be a standard version (ie. v1.390.0) or it can
+# be latest, in which case the latest released version will be used.
 #
-# The second argument is the platform, in the format used by the `runner.os` context variable
-# in GitHub Actions. Note that this script does not currently support Windows based environments.
+# The second argument is the platform, in the format used by the `runner.os`
+# context variable in GitHub Actions. Note that this script does not currently
+# support Windows based environments.
 #
-# As an example, the following would install the latest version of Snyk for GitHub Actions for
-# a Linux runner:
+# The third argument is optional and specifies the CPU architecture, in the
+# format used by the `runner.arch` context variable in GitHub Actions (e.g.
+# X64, ARM64). When omitted, the architecture is auto-detected from `uname -m`.
 #
-#     ./snyk-setup.sh latest Linux
+# As an example, the following would install the latest version of Snyk for
+# GitHub Actions for a Linux x86_64 runner:
+#
+#     ./setup_snyk.sh latest Linux
+#
+# And for a Linux arm64 runner:
+#
+#     ./setup_snyk.sh latest Linux ARM64
 #
 
 echo_with_timestamp() {
@@ -24,32 +33,53 @@ die () {
 }
 
 # Check if correct number of arguments is provided
-[ "$#" -eq 2 ] || die "Setup Snyk requires two arguments, $# provided"
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    die "Setup Snyk requires 2 or 3 arguments, $# provided"
+fi
 
 cd "$(mktemp -d)"
-echo_with_timestamp "Installing the $1 version of Snyk on $2"
+echo_with_timestamp "Installing the $1 version of Snyk on $2 ${3:-$(uname -m)}"
 
 VERSION=$1
+RUNNER_OS=$2
+RUNNER_ARCH="${3:-$(uname -m)}"
 MAIN_URL="https://downloads.snyk.io/cli"
 BACKUP_URL="https://static.snyk.io/cli"
 SUDO_CMD="sudo"
 GH_ACTIONS="GITHUB_ACTIONS"
 
-# Determine the prefix based on the platform
-case "$2" in
+# Determine the OS prefix
+case "$RUNNER_OS" in
     Linux)   PREFIX=linux ;;
     macOS)   PREFIX=macos ;;
     Alpine)  PREFIX=alpine ;;
     Windows) die "Windows runner not currently supported" ;;
-    *)       die "Invalid runner specified: $2" ;;
+    *)       die "Invalid runner specified: $RUNNER_OS" ;;
 esac
+
+# Determine the arch suffix. Snyk publishes arm64 binaries for linux, macos,
+# and alpine.
+case "$RUNNER_ARCH" in
+    X64|x64|x86_64|amd64)
+        ARCH_SUFFIX="" ;;
+    ARM64|arm64|aarch64)
+        case "$PREFIX" in
+            linux|macos|alpine) ARCH_SUFFIX="-arm64" ;;
+            *)                  die "No arm64 binary available for $RUNNER_OS" ;;
+        esac
+        ;;
+    *)
+        die "Invalid architecture specified: $RUNNER_ARCH" ;;
+esac
+
+BINARY="snyk-${PREFIX}${ARCH_SUFFIX}"
 
 {
     echo "#!/bin/bash"
     echo export SNYK_INTEGRATION_NAME=\"$GH_ACTIONS\"
-    echo export SNYK_INTEGRATION_VERSION=\"setup \(${2}\)\"
+    echo export SNYK_INTEGRATION_VERSION=\"setup \(${RUNNER_OS}\)\"
     echo export FORCE_COLOR=2
-    echo eval snyk-${PREFIX} \$@
+    echo eval ${BINARY} \$@
 } > snyk
 
 if ! command -v "$SUDO_CMD" &> /dev/null; then
@@ -82,34 +112,34 @@ download_file() {
     fi
 
     echo_with_timestamp "Validating shasum"
-    if ! sha256sum -c snyk-${PREFIX}.sha256; then
+    if ! sha256sum -c ${BINARY}.sha256; then
         echo_with_timestamp "Actual: "
-        sha256sum snyk-${PREFIX}
+        sha256sum ${BINARY}
 
         echo_with_timestamp "Expected: "
-        cat snyk-${PREFIX}.sha256
+        cat ${BINARY}.sha256
 
         echo_with_timestamp "Shasum validation failed"
         return 1
     fi
 }
 
-if ! download_file "$MAIN_URL/$VERSION" "snyk-${PREFIX}"; then
+if ! download_file "$MAIN_URL/$VERSION" "${BINARY}"; then
     echo_with_timestamp "Failed to download and validate Snyk files"
-    
+
     echo_with_timestamp "Retrying download with secondary URL"
-    if ! download_file "$BACKUP_URL/$VERSION" "snyk-${PREFIX}"; then
+    if ! download_file "$BACKUP_URL/$VERSION" "${BINARY}"; then
         die "Failed to download and validate Snyk files"
     fi
 fi
 
 
 # Make the binary executable
-chmod +x snyk-${PREFIX}
+chmod +x ${BINARY}
 
 echo_with_timestamp "Moving and cleaning files"
 # Move the binary to /usr/local/bin
-${SUDO_CMD} mv snyk-${PREFIX} /usr/local/bin
+${SUDO_CMD} mv ${BINARY} /usr/local/bin
 rm -rf snyk*
 
 echo_with_timestamp "Installed Snyk v$(snyk -v)"


### PR DESCRIPTION
## Problem

`setup/setup_snyk.sh` branches only on `runner.os` and unconditionally downloads the amd64 binary (e.g. `snyk-linux`). On arm64 runners — increasingly common with AWS CodeBuild, Apple Silicon self-hosted runners, and the GA `ubuntu-24.04-arm` images — the binary cannot exec:

```
/usr/local/bin/snyk: line 5: /usr/local/bin/snyk-linux: cannot execute binary file: Exec format error
Installed Snyk v        # empty version
```

Subsequent `snyk` invocations exit with code 126 (command found but not executable) in ~9 ms, masking the real failure. This was first hit in a real downstream workflow on a CodeBuild ARM64 runner.

Snyk already publishes arm64 binaries at the same CDN — `snyk-linux-arm64`, `snyk-macos-arm64`, `snyk-alpine-arm64` (all return HTTP 200 from `https://downloads.snyk.io/cli/latest/`) — they're just never selected.

## Change

1. **`setup/setup_snyk.sh`** — accepts an optional 3rd positional arg for CPU architecture. When omitted, falls back to `uname -m`, so existing 2-arg callers keep working. New case statement maps:
   - `X64` / `x86_64` / `amd64` → `""` (default binary, unchanged behavior)
   - `ARM64` / `aarch64` / `arm64` → `-arm64`
   - anything else → `die` with a clear message
   - arm64 is only accepted for platforms where Snyk publishes a binary (linux, macos, alpine).
   - Introduces `BINARY="snyk-${PREFIX}${ARCH_SUFFIX}"` so download/checksum/move all stay consistent.

2. **`setup/action.yml`** — new optional `arch` input defaulting to `${{ runner.arch }}`, plumbed through as the third arg.

## Backwards compatibility

| Runner OS | Runner Arch | Resolves to | vs. today |
|---|---|---|---|
| Linux | X64 / x86_64 | `snyk-linux` | unchanged |
| Linux | ARM64 / aarch64 | `snyk-linux-arm64` | **fix** |
| macOS | X64 | `snyk-macos` | unchanged |
| macOS | ARM64 | `snyk-macos-arm64` | **fix** |
| Alpine | X64 | `snyk-alpine` | unchanged |
| Alpine | ARM64 | `snyk-alpine-arm64` | **fix** |
| Windows | * | die (existing behavior) | unchanged |

Existing callers that pass only 2 args (version, OS) keep working because the script falls back to `uname -m` for the arch. The action's `arch` input defaults to `runner.arch`, so existing workflows that only set `os` (or accept the default) are unaffected.

## Test plan

- [x] Smoke-tested all 8 OS×arch combinations through the `case` logic locally.
- [x] Verified the three new arm64 URLs (`snyk-linux-arm64`, `snyk-macos-arm64`, `snyk-alpine-arm64`) all return HTTP 200 from `downloads.snyk.io/cli/latest/`.
- [x] `bash -n setup_snyk.sh` passes.
- [ ] CI on this PR.