### PR TITLE
chore: add prodsec-orb-runtime context to config.yaml [PRODSEC-10647]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,10 @@ workflows:
           name: scan repository for secrets
           context:
             - snyk-bot-slack
+            - prodsec-orb-runtime
           channel: cli-alerts
 
       - security-scans:
-          context: devex_cli
+          context:
+            - devex_cli
+            - prodsec-orb-runtime

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/cli @snyk/productinfra_cli
+* @snyk/cli @snyk/productinfra_cli @snyk/developer-experience_cli

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/cli @snyk/productinfra_cli @snyk/developer-experience_cli
+* @snyk/developer-experience_cli

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
 
             - name: Get next version with semver-action
               id: semver
-              uses: ietf-tools/semver-action@v1
+              uses: ietf-tools/semver-action@000ddb2ebacad350ff2a15382a344dc05ea4c0a4
               with:
                 branch: main
                 token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@ name: Release
 on:
     push:
         branches:
-            - main
             - master
 
 jobs:
@@ -20,7 +19,7 @@ jobs:
               id: semver
               uses: ietf-tools/semver-action@000ddb2ebacad350ff2a15382a344dc05ea4c0a4
               with:
-                branch: main
+                branch: ${{ github.ref_name }}	
                 token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Create tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+    push:
+        branches:
+            - main
+            - master
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+    
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Get next version with semver-action
+              id: semver
+              uses: ietf-tools/semver-action@v1
+              with:
+                branch: main
+                token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Create tag
+              run: |
+                git tag ${{ steps.semver.outputs.next }}
+                git tag ${{ steps.semver.outputs.nextMajor }}
+
+            - name: Push tag
+              run: git push --tags --force            
+
+            - name: Create GitHub Release with gh cli
+              run: gh release create ${{ steps.semver.outputs.next }} --generate-notes
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/synchronize-snyk-variants.yml
+++ b/.github/workflows/synchronize-snyk-variants.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '0 3 1 * *'
 
+permissions:
+  contents: write
+
 env:
   DESTINATION_BRANCH: auto/synchronize-snyk-variants
   COMMIT_MESSAGE: 'fix: synchronize actions with the snyk-images repository'
@@ -20,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.TEAM_CLI_BOT_GITHUB_PAT }}
 
       - name: Configure Git user
         run: |
@@ -77,6 +81,8 @@ jobs:
 
       - name: Commit and push changes (if any)
         if: steps.check_changes.outputs.continue == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.TEAM_CLI_BOT_GITHUB_PAT }}
         run: |
           git add .
           git commit -S -m "${{ env.COMMIT_MESSAGE }}"

--- a/.github/workflows/test-generated-actions.yml
+++ b/.github/workflows/test-generated-actions.yml
@@ -31,7 +31,6 @@ jobs:
           - elixir-1.18
           - golang
           - gradle
-          - gradle-jdk11
           - gradle-8-jdk17
           - gradle-9-jdk17
           - gradle-8-jdk21
@@ -79,12 +78,6 @@ jobs:
       - name: Run Snyk Gradle Action
         if: matrix.variant == 'gradle'
         uses: ./gradle/
-        with:
-          command: help
-
-      - name: Run Snyk Gradle-jdk11 Action
-        if: matrix.variant == 'gradle-jdk11'
-        uses: ./gradle-jdk11/
         with:
           command: help
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,3 +3,33 @@
 To ensure the long-term stability and quality of this project, we are moving to a closed-contribution model effective August 2025. This change allows our core team to focus on a centralized development roadmap and rigorous quality assurance, which is essential for a component with such extensive usage.
 
 All of our development will remain public for transparency. We thank the community for its support and valuable contributions.
+
+Here is an adjusted `CONTRIBUTING.md` file designed for both external users and Snyk engineers. It clearly separates the public-facing policy from the internal-facing development and release instructions.
+
+-----
+
+## **Internal Contributions (for Snyk Engineers)**
+
+### **The Release Process**
+
+Our project uses an automated release workflow to ensure new versions are consistent and error-free. The release is [triggered automatically](./.github/workflows/release.yaml) whenever a pull request is merged into the `main` branch.
+
+The process uses [semantic versioning](https://semver.org/) to automatically determine the next version number based on the [commit messages](https://www.conventionalcommits.org/en/v1.0.0/) in the merged pull request.
+
+### **How to Trigger a Major Version Change**
+
+A major version change (e.g., `v1.x.x` to `v2.0.0`) is reserved for significant, **breaking changes** to the project.
+
+To trigger a major version bump, your pull request **must** contain at least one commit message that includes the `BREAKING CHANGE:` footer.
+
+**Example Commit Message:**
+
+```text
+feat: Add a new API endpoint for user authentication
+
+This commit introduces a new /api/v1/auth endpoint.
+
+BREAKING CHANGE: The old authentication method is no longer supported. Please use the new endpoint.
+```
+
+The presence of this specific footer signals to the automated release workflow that a new major version is required. Without it, the workflow will only increment the patch or minor version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,32 +1,5 @@
-# Contributing to [APPLICATION_NAME]
+# Contributing
 
-Welcome, and thank you for your interest in contributing!
+To ensure the long-term stability and quality of this project, we are moving to a closed-contribution model effective August 2025. This change allows our core team to focus on a centralized development roadmap and rigorous quality assurance, which is essential for a component with such extensive usage.
 
-The goal of this document is to provide a high-level overview of how you can contribute and explain how we accept contribution.
-
-# Reporting issues
-Please use [official Snyk support website](https://support.snyk.io) to report any issues. Our technical support team will work together with you to resolve an issue, or pass it on to our engineers for resolution.
-
-You can find recommended information to include in the ticket on the [technical support guide page](https://support.snyk.io/hc/en-us/articles/5930557657885-Snyk-Technical-Support-Guide).
-
-# Providing feedback or suggestions
-Similarly to bug reports, we accept improvement suggestions and feedback via [the official support website](https://support.snyk.io).
-
-Please refer to the [support knowledge base](https://support.snyk.io/) and [user docs](https://docs.snyk.io) to verify that your suggestion isn't already part of our product before submitting a ticket with us.
-
-# Contributing code changes
-We are thrilled that you are interested in contributing code changes! Because this project is part of Snyk’s overall software offering, we want to make sure that your contribution aligns with our vision and product strategy, so please reach out to us before submitting a pull request. If you’re thinking of contributing a new feature, contact [our support](https://support.snyk.io) with a detailed explanation of your planned contribution and we'll be happy to discuss it with you. If you’re thinking of contributing a bug fix, we’d still like you to raise a support ticket first, as it’s possible we may already be working on a fix.
-
-Once we've confirmed that we're ready to accept your contribution, feel free to open a pull request and link it in the support ticket. We're excited to work with you to get your contribution merged and make our project even better!
-
-## Contributor License Agreement
-As part of the PR process, you'll need to sign a Contributor License Agreement (CLA). It is an automated process and you'll only need to do it once, when contributing first time. You won't need to sign it in future when contributing to other Snyk projects.
-
-## Pipeline checks
-We don't allow external contributors to run pipeline status checks on your PR for security reasons. We'll run them on your behalf when you mark your PR changes as ready for us.
-
-## Code of Conduct
-Please make sure to read and follow the [Code of Conduct](./code-of-conduct.md).
-
-## Contribution instructions
-If your proposal for contribution has been accepted, read the instructions below on how to work with and contribute to this project.
+All of our development will remain public for transparency. We thank the community for its support and valuable contributions.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ you are using.
 - [elixir-1.18](elixir-1.18)
 - [Golang](golang)
 - [Gradle](gradle)
-- [Gradle-jdk11](gradle-jdk11)
 - [gradle-8-jdk17](gradle-8-jdk17)
 - [gradle-9-jdk17](gradle-9-jdk17)
 - [gradle-8-jdk21](gradle-8-jdk21)
@@ -164,6 +163,7 @@ The following actions are deprecated and no longer supported by Snyk or the down
 
 
 - [dotNET](dotnet)
+- [Gradle-jdk11](gradle-jdk11)
 - [Gradle-jdk12](gradle-jdk12)
 - [Gradle-jdk14](gradle-jdk14)
 - [Gradle-jdk16](gradle-jdk16)

--- a/README.md
+++ b/README.md
@@ -177,7 +177,18 @@ The following actions are deprecated and no longer supported by Snyk or the down
 - [Scala](scala)
 
 
-Made with 💜 by Snyk
+## Contributing
+
+To ensure the long-term stability and quality of this project, we are moving to a closed-contribution model effective August 2025. This change allows our core team to focus on a centralized development roadmap and rigorous quality assurance, which is essential for a component with such extensive usage.
+
+All of our development will remain public for transparency. We thank the community for its support and valuable contributions.
+
+## Getting Support
+
+GitHub issues have been disabled on this repository as part of our move to a closed-contribution model. The Snyk support team does not actively monitor GitHub issues on any Snyk development project.
+
+For help with Snyk products, please use the [Snyk support page](https://support.snyk.io/), which is the fastest way to get assistance.
 
 [cli-gh]: https://github.com/snyk/snyk 'Snyk CLI'
 [cli-ref]: https://docs.snyk.io/snyk-cli/cli-reference 'Snyk CLI Reference documentation'
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+## Reporting Security Issues
+
+To report a security vulnerability to us, please see https://docs.snyk.io/snyk-data-and-governance/reporting-security-issues.

--- a/_templates/BASE.md.erb
+++ b/_templates/BASE.md.erb
@@ -142,7 +142,18 @@ The following actions are deprecated and no longer supported by Snyk or the down
 - [<%= variant %>](<%= variant.downcase %>)<% end %>
 <% end %>
 
-Made with 💜 by Snyk
+## Contributing
+
+To ensure the long-term stability and quality of this project, we are moving to a closed-contribution model effective August 2025. This change allows our core team to focus on a centralized development roadmap and rigorous quality assurance, which is essential for a component with such extensive usage.
+
+All of our development will remain public for transparency. We thank the community for its support and valuable contributions.
+
+## Getting Support
+
+GitHub issues have been disabled on this repository as part of our move to a closed-contribution model. The Snyk support team does not actively monitor GitHub issues on any Snyk development project.
+
+For help with Snyk products, please use the [Snyk support page](https://support.snyk.io/), which is the fastest way to get assistance.
 
 [cli-gh]: https://github.com/snyk/snyk 'Snyk CLI'
 [cli-ref]: https://docs.snyk.io/snyk-cli/cli-reference 'Snyk CLI Reference documentation'
+

--- a/_templates/README.md.erb
+++ b/_templates/README.md.erb
@@ -71,10 +71,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for <%= @name %> using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -85,7 +96,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/_templates/README.md.erb
+++ b/_templates/README.md.erb
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk <%= @name %><% if @ident %> (<%= @ident %>) <% end %> Action
 
-<% if @is_deprecated %>## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.<% end %>
+<% if @is_deprecated %>> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.<% end %>
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your <%= @variant %> projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/cocoapods/README.md
+++ b/cocoapods/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for CocoaPods using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for dotNET using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk dotNET Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your dotNET projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/elixir-1.18/README.md
+++ b/elixir-1.18/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for elixir using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/golang/README.md
+++ b/golang/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Golang using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-8-jdk17/README.md
+++ b/gradle-8-jdk17/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-8-jdk21/README.md
+++ b/gradle-8-jdk21/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-8-jdk24/README.md
+++ b/gradle-8-jdk24/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-9-jdk17/README.md
+++ b/gradle-9-jdk17/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-9-jdk21/README.md
+++ b/gradle-9-jdk21/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-9-jdk24/README.md
+++ b/gradle-9-jdk24/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk11/README.md
+++ b/gradle-jdk11/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk11/README.md
+++ b/gradle-jdk11/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Gradle (jdk11)  Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk11 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/gradle-jdk11/README.md
+++ b/gradle-jdk11/README.md
@@ -4,7 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Gradle (jdk11)  Action
 
-
+## :warning: Deprecated Action
+This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk11 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/gradle-jdk11/action.yml
+++ b/gradle-jdk11/action.yml
@@ -16,13 +16,17 @@ inputs:
     description: "Output a snyk.json file with results if running the test command"
     default: false
 runs:
-  using: "docker"
-  image: "docker://snyk/snyk:gradle-jdk11"
-  env:
-    FORCE_COLOR: 2
-    SNYK_INTEGRATION_NAME: GITHUB_ACTIONS
-    SNYK_INTEGRATION_VERSION: gradle-jdk11
-  args:
-  - snyk
-  - ${{ inputs.command }}
-  - ${{ inputs.args }}
+  using: "composite"
+  steps:
+    - name: Show deprecation warning
+      shell: bash
+      run: echo "::warning title=Deprecated Action::The action gradle-jdk11 is deprecated. Please visit Snyk actions at https://github.com/snyk/actions for a newer version."
+
+    - name: Run Snyk scan
+      uses: docker://snyk/snyk:gradle-jdk11
+      env:
+        FORCE_COLOR: 2
+        SNYK_INTEGRATION_NAME: GITHUB_ACTIONS
+        SNYK_INTEGRATION_VERSION: gradle-jdk11
+      with:
+        args: snyk ${{ inputs.command }} ${{ inputs.args }}

--- a/gradle-jdk12/README.md
+++ b/gradle-jdk12/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk12/README.md
+++ b/gradle-jdk12/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Gradle (jdk12)  Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk12 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/gradle-jdk14/README.md
+++ b/gradle-jdk14/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk14/README.md
+++ b/gradle-jdk14/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Gradle (jdk14)  Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk14 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/gradle-jdk16/README.md
+++ b/gradle-jdk16/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk16/README.md
+++ b/gradle-jdk16/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Gradle (jdk16)  Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk16 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/gradle-jdk17/README.md
+++ b/gradle-jdk17/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk17/README.md
+++ b/gradle-jdk17/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Gradle (jdk17)  Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk17 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/gradle-jdk21/README.md
+++ b/gradle-jdk21/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/gradle-jdk21/README.md
+++ b/gradle-jdk21/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Gradle (jdk21)  Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Gradle-jdk21 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Gradle using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-11/README.md
+++ b/maven-3-jdk-11/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-17/README.md
+++ b/maven-3-jdk-17/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-20/README.md
+++ b/maven-3-jdk-20/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-20/README.md
+++ b/maven-3-jdk-20/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Maven (3-jdk-20)  Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Maven-3-jdk-20 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/maven-3-jdk-21/README.md
+++ b/maven-3-jdk-21/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-22/README.md
+++ b/maven-3-jdk-22/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven-3-jdk-22/README.md
+++ b/maven-3-jdk-22/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Maven (3-jdk-22)  Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Maven-3-jdk-22 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/maven-3-jdk-24/README.md
+++ b/maven-3-jdk-24/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/maven/README.md
+++ b/maven/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Maven using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/node/README.md
+++ b/node/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Node using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/php/README.md
+++ b/php/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for PHP using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.10/README.md
+++ b/python-3.10/README.md
@@ -70,10 +70,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -84,7 +95,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.11/README.md
+++ b/python-3.11/README.md
@@ -70,10 +70,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -84,7 +95,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.12/README.md
+++ b/python-3.12/README.md
@@ -70,10 +70,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -84,7 +95,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.6/README.md
+++ b/python-3.6/README.md
@@ -71,10 +71,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -85,7 +96,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.6/README.md
+++ b/python-3.6/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Python (3.6)  Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Python-3.6 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/python-3.7/README.md
+++ b/python-3.7/README.md
@@ -71,10 +71,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -85,7 +96,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.7/README.md
+++ b/python-3.7/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Python (3.7)  Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Python-3.7 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/python-3.8/README.md
+++ b/python-3.8/README.md
@@ -71,10 +71,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -85,7 +96,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python-3.8/README.md
+++ b/python-3.8/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Python (3.8)  Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Python-3.8 projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/python-3.9/README.md
+++ b/python-3.9/README.md
@@ -70,10 +70,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -84,7 +95,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -70,10 +70,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Python using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -84,7 +95,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Ruby using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/sbt1.10.0-scala3.4.2/README.md
+++ b/sbt1.10.0-scala3.4.2/README.md
@@ -63,10 +63,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for SBT1.10.0 using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -77,7 +88,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/scala/README.md
+++ b/scala/README.md
@@ -64,10 +64,21 @@ The Snyk Action will fail when vulnerabilities are found. This would prevent the
 
 ```yaml
 name: Example workflow for Scala using Snyk
+
 on: push
+
 jobs:
   security:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+      # If your repository is private, also add:
+      actions: read
+      contents: read
+
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
@@ -78,7 +89,7 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
 ```

--- a/scala/README.md
+++ b/scala/README.md
@@ -4,8 +4,8 @@ WARNING: This file is generated, do not edit! Edit _templates/README.md.erb inst
 
 # Snyk Scala Action
 
-## :warning: Deprecated Action
-This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
+> [!WARNING]
+> This action is deprecated and no longer supported by Snyk. Please consult the [docs](../README.md) for alternatives.
 
 A [GitHub Action](https://github.com/features/actions) for using [Snyk](https://snyk.co/SnykGH) to check for
 vulnerabilities in your Scala projects. This Action is based on the [Snyk CLI][cli-gh] and you can use [all of its options and capabilities][cli-ref] with the `args`.

--- a/variants
+++ b/variants
@@ -3,7 +3,7 @@ dotNET DEPRECATED
 elixir-1.18
 Golang
 Gradle
-Gradle-jdk11
+Gradle-jdk11 DEPRECATED
 Gradle-jdk12 DEPRECATED
 Gradle-jdk14 DEPRECATED
 Gradle-jdk16 DEPRECATED


### PR DESCRIPTION
## Summary
This PR adds the `prodsec-orb-runtime` context to jobs and workflows that use prodsec-orb commands.

## Changes
- Added `prodsec-orb-runtime` context to jobs using:
  - `prodsec/secrets-scan`
  - `prodsec/security_scans`
  - `prodsec/container_scan`
  - `publish/publish`

## Related
PRODSEC-10647
